### PR TITLE
Use internal Nexus to retrieve artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,12 @@
 //
 buildscript {
     repositories {
-        mavenCentral()
-        jcenter()
-        maven { url "http://dl.bintray.com/releashaus/release" }
+        maven {
+            url "${localNexusLocation}/public"
+        }
+        maven {
+            url "http://dl.bintray.com/releashaus/release"
+        }
     }
 
     dependencies {
@@ -24,8 +27,6 @@ configure(allprojects) { project ->
 
     // Version of main components
     ext {
-        // h2oBuild property is defined in gradle.properties
-        h2oVersion = "$h2oMajorVersion.$h2oBuild"
         junitVersion = '4.11'
     }
 }
@@ -45,21 +46,8 @@ configure(subprojects) { project ->
     version = rootProject.version
 
     repositories {
-        // Should be enabled only in development mode
-        if (h2oBuild == '99999' || project.hasProperty('useMavenLocal')) {
-            mavenLocal()
-        }
-
-        mavenCentral()
-
-        // Public Sonatype repository
         maven {
-            url "https://oss.sonatype.org/content/repositories/releases/"
-        }
-
-        // Snapshot repository of H2O builds
-        maven {
-            url "http://h2o-release.s3.amazonaws.com/h2o/master/$h2oBuild/maven/repo/"
+            url "${localNexusLocation}/public"
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,10 @@
 #Tue, 19 May 2015 17:15:25 -0700
 group=ai.h2o
 version=2.0.99999-SNAPSHOT
-# Major version of H2O release
-h2oMajorVersion=3.10.0
-# Name of H2O major version
-h2oMajorName=turing
-# H2O Build version, defined here to be overriden by -P option
-h2oBuild=7
 
 org.gradle.jvmargs='-XX:MaxPermSize=384m'
 
+#
+# Internal Nexus location
+#
+localNexusLocation=http://nexus:8081/nexus/repository


### PR DESCRIPTION
This allows us to not use HTTPS & enables build on Java 7
(Java 7 doesn't have all required certificates and TLS versions)

+ build clean-up