### PR TITLE
PUBDEV-7232 - Remove DeepWater Estimator Function - MojoLand tweaks

### DIFF
--- a/mojo-java/src/main/java/ai/h2o/mojos/server/core/MethodParam.java
+++ b/mojo-java/src/main/java/ai/h2o/mojos/server/core/MethodParam.java
@@ -1,5 +1,6 @@
 package ai.h2o.mojos.server.core;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 
 /**
@@ -264,6 +265,9 @@ enum MethodParam {
       case "hex.genmodel.PredictContributionsFactory":
       case "hex.genmodel.CategoricalEncoding":
       case "hex.genmodel.algos.tree.ConvertTreeOptions":
+      case "hex.genmodel.easy.EasyPredictModelWrapper$ErrorConsumer":
+      case "hex.genmodel.easy.EasyPredictModelWrapper$Config":
+      case "hex.genmodel.easy.RowToRawDataConverter": 
         return UNKNOWN;
     }
     throw new RuntimeException("Unknown parameter type: " + typeName);


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7232

I've added https://github.com/h2oai/h2o-3/pull/4393/files#diff-24bf9fdf9a700725bbd4147409b247c9R709

```java
  public RowToRawDataConverter getRawDataConverter(Map<String, Integer> modelColumnNameToIndexMap,

                                             Map<Integer, CategoricalEncoder> domainMap,

                                             EasyPredictModelWrapper.ErrorConsumer errorConsumer,
                                             EasyPredictModelWrapper.Config config){
        return new RowToRawDataConverter(this, modelColumnNameToIndexMap, domainMap,
            errorConsumer, config);
  }
```

method to `GenModel` - returns RowToRawDataConverter and accepts two suclasses of `EasyPredictModelWrapper`.

I think adding a non-static method to GenModel and not deleting anything should be fine. All the classes are `Serializable`. Is that correct, please ? 