### PR TITLE
PUBDEV-8367: Fixed failure due to new glm mojo being able to deal with offset columns

### DIFF
--- a/mojo-data/mojos/glm/cars/v1.00/glm_v1.00_cars_scores1.txt
+++ b/mojo-data/mojos/glm/cars/v1.00/glm_v1.00_cars_scores1.txt
@@ -1,406 +1,406 @@
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
+[15.367033442452353, 0.0]
+[13.863126375563912, 0.0]
+[17.525638898853458, 0.0]
+[26.962901811086926, 0.0]
+[26.15290883078117, 0.0]
+[33.00034026879588, 0.0]
+[29.519847327713162, 0.0]
+[33.70860845135371, 0.0]
+[30.381642560420527, 0.0]
+[30.783844549430324, 0.0]
+[33.118794072207635, 0.0]
+[32.00721190471421, 0.0]
+[31.746905199267044, 0.0]
+[33.22193581578108, 0.0]
+[35.43501838350302, 0.0]
+[37.45950316650165, 0.0]
+[38.8566911401839, 0.0]
+[30.474173160911597, 0.0]
+[32.16897247374772, 0.0]
+[35.26821963622268, 0.0]
+[38.08741708721236, 0.0]
+[37.783802671383185, 0.0]
+[39.91985973934006, 0.0]
+[40.72585983336011, 0.0]
+[46.2165818160647, 0.0]
+[46.2751274448693, 0.0]
+[38.9534908366344, 0.0]
+[42.598155846213615, 0.0]
+[55.78503840573593, 0.0]
+[52.82158070299978, 0.0]
+[54.64119822416794, 0.0]
+[53.582786418264135, 0.0]
+[63.61828495236071, 0.0]
+[58.88618821296686, 0.0]
+[60.819641156291866, 0.0]
+[61.99972696626409, 0.0]
+[59.742194881449734, 0.0]
+[63.613086640405854, 0.0]
+[51.668123835185696, 0.0]
+[67.04589929638972, 0.0]
+[50.66807580452735, 0.0]
+[63.34547053651164, 0.0]
+[59.012960523984404, 0.0]
+[67.3458049553319, 0.0]
+[52.25791384249469, 0.0]
+[62.926205215955946, 0.0]
+[62.57089760715256, 0.0]
+[57.38905588314255, 0.0]
+[77.57177559862522, 0.0]
+[70.76418098518303, 0.0]
+[72.25703569678943, 0.0]
+[64.97504521820699, 0.0]
+[79.8828281941195, 0.0]
+[74.37271802673051, 0.0]
+[83.61717217112371, 0.0]
+[74.6692064064654, 0.0]
+[70.0511968499232, 0.0]
+[73.98053070301201, 0.0]
+[71.04678530232209, 0.0]
+[87.38534551435733, 0.0]
+[71.38443087788953, 0.0]
+[80.86784567480812, 0.0]
+[79.96363394970392, 0.0]
+[94.9127964511679, 0.0]
+[94.37481575164712, 0.0]
+[95.65191140916637, 0.0]
+[77.09834257076142, 0.0]
+[79.94622023348768, 0.0]
+[84.90503677473143, 0.0]
+[84.10433115980452, 0.0]
+[87.4939372358912, 0.0]
+[86.16105576866366, 0.0]
+[101.9624393285479, 0.0]
+[103.38958998035751, 0.0]
+[104.34292073662427, 0.0]
+[107.04487313100879, 0.0]
+[104.49832290548758, 0.0]
+[105.60058055198584, 0.0]
+[105.77418386461835, 0.0]
+[99.76693837078805, 0.0]
+[88.07525538577953, 0.0]
+[92.76421881013228, 0.0]
+[93.43808723107924, 0.0]
+[92.75084638072933, 0.0]
+[105.29055467938313, 0.0]
+[99.40469340237175, 0.0]
+[109.86722952848994, 0.0]
+[103.14059748028973, 0.0]
+[109.65835645741528, 0.0]
+[102.80244385034527, 0.0]
+[103.5286119781212, 0.0]
+[111.70215768707514, 0.0]
+[111.43798563475792, 0.0]
+[112.75611178166524, 0.0]
+[113.65462283144694, 0.0]
+[115.99705533781594, 0.0]
+[119.77195332110519, 0.0]
+[121.49816268917012, 0.0]
+[122.52956358028108, 0.0]
+[124.32839006825986, 0.0]
+[125.03356240670043, 0.0]
+[130.14781311359408, 0.0]
+[118.15031883286602, 0.0]
+[112.68846840289079, 0.0]
+[133.9203076117738, 0.0]
+[120.23055758528298, 0.0]
+[136.58315533084325, 0.0]
+[131.07331861282287, 0.0]
+[127.18163286157248, 0.0]
+[118.6225043762683, 0.0]
+[120.91203975693898, 0.0]
+[129.54138959679938, 0.0]
+[140.69828547701755, 0.0]
+[141.72082142248416, 0.0]
+[143.59592756413437, 0.0]
+[147.11949234254618, 0.0]
+[149.90353553365023, 0.0]
+[149.2854511684007, 0.0]
+[144.4845644562113, 0.0]
+[153.35783309579688, 0.0]
+[152.722198270293, 0.0]
+[146.09150797559602, 0.0]
+[152.02863382262586, 0.0]
+[152.3829762253097, 0.0]
+[149.24216483069725, 0.0]
+[150.70710477885152, 0.0]
+[154.50405026078366, 0.0]
+[154.19585793862535, 0.0]
+[153.01389063451404, 0.0]
+[158.96451312877642, 0.0]
+[161.02168787814568, 0.0]
+[159.83298165593172, 0.0]
+[162.98483406129475, 0.0]
+[157.48903654451655, 0.0]
+[159.23161728188575, 0.0]
+[166.01602864110401, 0.0]
+[165.61104735869196, 0.0]
+[160.24505300747106, 0.0]
+[157.21737100909687, 0.0]
+[159.9476686232239, 0.0]
+[163.97674537377804, 0.0]
+[155.78189154072516, 0.0]
+[173.85053830181093, 0.0]
+[168.7895644072861, 0.0]
+[170.13788013384783, 0.0]
+[177.5512379089032, 0.0]
+[176.11835195497048, 0.0]
+[175.32019699109378, 0.0]
+[175.70699135738877, 0.0]
+[176.48766298418008, 0.0]
+[165.28038810933398, 0.0]
+[163.11100853195592, 0.0]
+[167.67227287854536, 0.0]
+[171.1202478180297, 0.0]
+[163.58321257636138, 0.0]
+[173.01480420234515, 0.0]
+[175.69759633051277, 0.0]
+[174.51363923789373, 0.0]
+[164.6790022069434, 0.0]
+[175.38347795403863, 0.0]
+[189.81089430170368, 0.0]
+[193.25706123714866, 0.0]
+[181.94039415061965, 0.0]
+[188.90514224563506, 0.0]
+[190.73043210507817, 0.0]
+[190.64028433445625, 0.0]
+[193.64943425939637, 0.0]
+[195.64120052399718, 0.0]
+[194.8758224522183, 0.0]
+[200.1846109363314, 0.0]
+[198.3540747404107, 0.0]
+[197.20475939926177, 0.0]
+[180.07985699183394, 0.0]
+[191.50964019414766, 0.0]
+[182.5682393109081, 0.0]
+[206.3996629497376, 0.0]
+[209.30813572891196, 0.0]
+[194.4216278513496, 0.0]
+[186.18543848740788, 0.0]
+[203.96402520311847, 0.0]
+[206.77065782763313, 0.0]
+[207.52448606903084, 0.0]
+[210.8622998605523, 0.0]
+[210.43748805139194, 0.0]
+[216.55431646491363, 0.0]
+[207.9608414197549, 0.0]
+[198.7553817636331, 0.0]
+[198.879055174586, 0.0]
+[197.85819692706113, 0.0]
+[200.7812969330481, 0.0]
+[201.06248132377482, 0.0]
+[205.06103788138222, 0.0]
+[207.16477286926064, 0.0]
+[207.14100805127893, 0.0]
+[213.94177398888047, 0.0]
+[221.64992133373977, 0.0]
+[224.74669693680312, 0.0]
+[217.87992196119842, 0.0]
+[218.4944391349045, 0.0]
+[210.99557959225464, 0.0]
+[211.62986826851792, 0.0]
+[222.78898628674412, 0.0]
+[223.01287908621947, 0.0]
+[225.62103273557778, 0.0]
+[225.45576209313475, 0.0]
+[228.27540854888872, 0.0]
+[221.90220746437177, 0.0]
+[234.00158531541456, 0.0]
+[237.30433420428614, 0.0]
+[234.8243435692406, 0.0]
+[231.01236289230508, 0.0]
+[229.66599461030134, 0.0]
+[236.39963713457058, 0.0]
+[238.5088318477133, 0.0]
+[236.48868456728783, 0.0]
+[240.81957292817998, 0.0]
+[241.14960735956424, 0.0]
+[242.99853234514165, 0.0]
+[243.5562376702363, 0.0]
+[245.1935615814414, 0.0]
+[250.49028952354618, 0.0]
+[236.23027541973283, 0.0]
+[233.77316914496643, 0.0]
+[240.67452206248825, 0.0]
+[239.41927859969272, 0.0]
+[232.59190223602545, 0.0]
+[256.4574769631445, 0.0]
+[257.52301356322045, 0.0]
+[259.04909309718533, 0.0]
+[261.9448078619098, 0.0]
+[264.5236134981144, 0.0]
+[266.1029338848692, 0.0]
+[265.67482446231077, 0.0]
+[263.5187245324207, 0.0]
+[266.65186069621, 0.0]
+[260.2193123313297, 0.0]
+[267.2560198894858, 0.0]
+[271.4866158359855, 0.0]
+[270.1649071935968, 0.0]
+[271.1980970149036, 0.0]
+[266.83621718895847, 0.0]
+[270.48129515712895, 0.0]
+[271.6709494827946, 0.0]
+[276.6681175113369, 0.0]
+[278.27070021027936, 0.0]
+[279.59136798549133, 0.0]
+[277.6079931598101, 0.0]
+[279.21845015321236, 0.0]
+[272.7693806509002, 0.0]
+[274.9924472345984, 0.0]
+[280.0786512720122, 0.0]
+[276.22197178961903, 0.0]
+[269.9716766995696, 0.0]
+[275.47124501115917, 0.0]
+[278.67255806350846, 0.0]
+[279.2237594386698, 0.0]
+[271.4359864040397, 0.0]
+[276.08831786451594, 0.0]
+[291.5931369005819, 0.0]
+[267.2505977555587, 0.0]
+[269.5190625698632, 0.0]
+[281.7068853079225, 0.0]
+[282.11277361625025, 0.0]
+[288.67328231458833, 0.0]
+[288.33886806242185, 0.0]
+[298.2471034507124, 0.0]
+[293.78338079330086, 0.0]
+[289.3728069936974, 0.0]
+[290.10959458931114, 0.0]
+[291.8665795052582, 0.0]
+[287.09919962366746, 0.0]
+[281.6806078102184, 0.0]
+[299.18602438605063, 0.0]
+[289.35266310607597, 0.0]
+[300.0427011067567, 0.0]
+[286.0821738538071, 0.0]
+[304.53165014539155, 0.0]
+[302.28124202227895, 0.0]
+[304.6309401635297, 0.0]
+[305.3765166498623, 0.0]
+[305.8353099261943, 0.0]
+[301.8389388852049, 0.0]
+[304.0710669269882, 0.0]
+[306.0748654247621, 0.0]
+[305.1979019260081, 0.0]
+[310.0112896741758, 0.0]
+[312.0019193205579, 0.0]
+[309.0193268192953, 0.0]
+[316.68843850443153, 0.0]
+[303.3143140094652, 0.0]
+[324.38800725384766, 0.0]
+[317.6710931796451, 0.0]
+[302.13895085076945, 0.0]
+[314.143203493093, 0.0]
+[313.84348556499094, 0.0]
+[316.64276405953547, 0.0]
+[308.8308018257751, 0.0]
+[309.1697339745144, 0.0]
+[307.97275064067645, 0.0]
+[311.6888721184145, 0.0]
+[317.6881401973467, 0.0]
+[313.64375975712085, 0.0]
+[334.1634799400896, 0.0]
+[336.47211182836526, 0.0]
+[335.09033530933414, 0.0]
+[335.68013833776683, 0.0]
+[336.4818336173003, 0.0]
+[338.00656853221847, 0.0]
+[334.6957736866822, 0.0]
+[319.94178569628787, 0.0]
+[323.0868998073558, 0.0]
+[327.74328796387397, 0.0]
+[329.90908161676117, 0.0]
+[328.55000631550365, 0.0]
+[334.86757896488007, 0.0]
+[335.318700662339, 0.0]
+[337.77389569558125, 0.0]
+[337.09449685915285, 0.0]
+[334.8926864019275, 0.0]
+[341.09203272058966, 0.0]
+[345.5331787789489, 0.0]
+[330.85701280758326, 0.0]
+[333.13216634658045, 0.0]
+[332.3473525546427, 0.0]
+[335.52349202976956, 0.0]
+[342.7686351103838, 0.0]
+[341.8514758429902, 0.0]
+[339.3933266331323, 0.0]
+[358.6663153459498, 0.0]
+[352.9255107423175, 0.0]
+[351.5321023970212, 0.0]
+[360.7998288539936, 0.0]
+[360.4652253001891, 0.0]
+[338.5523684626157, 0.0]
+[359.95044938594896, 0.0]
+[354.2129231068179, 0.0]
+[361.7915002710615, 0.0]
+[365.53550813582405, 0.0]
+[369.5031320315765, 0.0]
+[370.8461448026725, 0.0]
+[373.9215494793401, 0.0]
+[369.43944745220193, 0.0]
+[365.0854351593193, 0.0]
+[369.2564299928369, 0.0]
+[367.3217736469021, 0.0]
+[369.70686626990306, 0.0]
+[376.72982284343067, 0.0]
+[379.01702551993384, 0.0]
+[373.8556420312517, 0.0]
+[382.2615883069301, 0.0]
+[375.9999912612469, 0.0]
+[379.03767623511084, 0.0]
+[382.0158503425512, 0.0]
+[380.72685748187047, 0.0]
+[383.6566719620005, 0.0]
+[381.2721129291758, 0.0]
+[385.0259593509864, 0.0]
+[390.1840925392227, 0.0]
+[386.89300188221637, 0.0]
+[387.02676906158354, 0.0]
+[391.1139383703892, 0.0]
+[392.3964978317495, 0.0]
+[394.8202554516661, 0.0]
+[388.10173966927374, 0.0]
+[392.3072469257112, 0.0]
+[387.98790174098815, 0.0]
+[390.5424986973626, 0.0]
+[391.6002237337396, 0.0]
+[395.7176529975287, 0.0]
+[399.6336981269709, 0.0]
+[397.3647698626997, 0.0]
+[394.59749325774584, 0.0]
+[394.0432287566259, 0.0]
+[408.175099995935, 0.0]
+[407.320759566015, 0.0]
+[398.5988064828956, 0.0]
+[405.6187226718295, 0.0]
+[410.7858877987911, 0.0]
+[404.72279173650634, 0.0]
+[402.76676611466553, 0.0]
+[411.10104733907883, 0.0]
+[408.71060688614125, 0.0]
+[410.5647035136239, 0.0]
+[412.28787745482697, 0.0]
+[416.27968996577846, 0.0]
+[412.38363405077513, 0.0]
+[419.9566235630924, 0.0]
+[419.59706726498143, 0.0]
+[419.74202604242885, 0.0]
+[419.91074650802875, 0.0]
+[422.4563456173759, 0.0]
+[425.42586101336076, 0.0]
+[421.411481862891, 0.0]
+[423.1646333608685, 0.0]
+[424.78782900271096, 0.0]
+[426.84502511893385, 0.0]
+[427.3448841444277, 0.0]
+[423.52149104853555, 0.0]
+[426.24016618542146, 0.0]
+[424.6769537746663, 0.0]
+[422.06715066932856, 0.0]
+[421.8552669706018, 0.0]
+[425.0149908898406, 0.0]
+[425.5204272224723, 0.0]
+[427.63797968924365, 0.0]
+[431.0549719995962, 0.0]

--- a/mojo-data/mojos/glm/eyestate/v1.00/glm_v1.00_eyestate_scores1.txt
+++ b/mojo-data/mojos/glm/eyestate/v1.00/glm_v1.00_eyestate_scores1.txt
@@ -1,2140 +1,2140 @@
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
+[1.0, 0.5271094348722112, 0.4728905651277888]
+[1.0, 0.3503434630687907, 0.6496565369312093]
+[1.0, 0.14897512106149935, 0.8510248789385007]
+[1.0, 0.08920325494341752, 0.9107967450565825]
+[1.0, 0.027897989317334337, 0.9721020106826657]
+[1.0, 0.010753728825675712, 0.9892462711743243]
+[1.0, 0.0025047167887952693, 0.9974952832112047]
+[1.0, 0.0012598494587984232, 0.9987401505412016]
+[1.0, 4.615185855391113E-4, 0.9995384814144609]
+[1.0, 1.5810094620238857E-4, 0.9998418990537976]
+[1.0, 5.755347865843419E-5, 0.9999424465213416]
+[1.0, 2.203686863178067E-5, 0.9999779631313682]
+[1.0, 5.73627217348438E-6, 0.9999942637278265]
+[1.0, 2.1279542283814123E-6, 0.9999978720457716]
+[1.0, 8.31082411889561E-7, 0.9999991689175881]
+[1.0, 3.5748459803475185E-7, 0.999999642515402]
+[1.0, 1.0788372917236444E-7, 0.9999998921162708]
+[1.0, 4.441204293215151E-8, 0.9999999555879571]
+[1.0, 1.551855643988631E-8, 0.9999999844814436]
+[1.0, 9.492399866140033E-9, 0.9999999905076001]
+[1.0, 3.002173842858724E-9, 0.9999999969978262]
+[1.0, 2.32853247794651E-9, 0.9999999976714675]
+[1.0, 1.344686140214435E-9, 0.9999999986553139]
+[1.0, 2.290256873038743E-10, 0.9999999997709743]
+[1.0, 3.8505421073864454E-11, 0.9999999999614946]
+[1.0, 6.7701400041642046E-12, 0.9999999999932299]
+[1.0, 1.715960706860642E-12, 0.999999999998284]
+[1.0, 4.0101255649460654E-13, 0.999999999999599]
+[1.0, 1.1812772982011666E-13, 0.9999999999998819]
+[1.0, 3.26405569239796E-14, 0.9999999999999674]
+[1.0, 1.3988810110276972E-14, 0.999999999999986]
+[1.0, 4.884981308350689E-15, 0.9999999999999951]
+[1.0, 1.9984014443252818E-15, 0.999999999999998]
+[1.0, 1.3322676295501878E-15, 0.9999999999999987]
+[1.0, 6.661338147750939E-16, 0.9999999999999993]
+[1.0, 2.220446049250313E-16, 0.9999999999999998]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]

--- a/mojo-data/mojos/glm/iris/v1.00/glm_v1.00_iris_scores1.txt
+++ b/mojo-data/mojos/glm/iris/v1.00/glm_v1.00_iris_scores1.txt
@@ -1,150 +1,150 @@
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
+[0.0, 0.9983186829138291, 0.001681317086167192, 3.689414582309605E-15]
+[0.0, 0.9909144333179544, 0.009085566681940003, 1.0566022974533204E-13]
+[0.0, 0.9980791176028425, 0.0019208823971468719, 1.0566824372301579E-14]
+[0.0, 0.9969193572199326, 0.0030806427800120504, 5.541564317416297E-14]
+[0.0, 0.9991705468036662, 8.29453196332216E-4, 1.5231245194646837E-15]
+[0.0, 0.9982403161504841, 0.0017596838495001245, 1.5665387553891372E-14]
+[0.0, 0.9990531428741045, 9.468571258841196E-4, 1.1380062938686022E-14]
+[0.0, 0.9976692869369739, 0.002330713063014973, 1.1296834530753268E-14]
+[0.0, 0.99618062951162, 0.0038193704882767982, 1.0330978838275434E-13]
+[0.0, 0.9949677998872659, 0.005032200112706383, 2.7553310857456366E-14]
+[0.0, 0.9982369819566135, 0.0017630180433843875, 2.3025105850462248E-15]
+[0.0, 0.9984052130945348, 0.0015947869054510127, 1.428783522299454E-14]
+[0.0, 0.9947909917028759, 0.005209008297095308, 2.8744625974010194E-14]
+[0.0, 0.9990953435542211, 9.046564457760922E-4, 2.680064412514788E-15]
+[0.0, 0.9991398007135961, 8.601992864037789E-4, 9.32951952008648E-17]
+[0.0, 0.9996856632400786, 3.143367599211479E-4, 2.1561117365553975E-16]
+[0.0, 0.9990189788339193, 9.810211660789235E-4, 1.818176639660672E-15]
+[0.0, 0.9977386134107944, 0.002261386589193945, 1.1685434649203976E-14]
+[0.0, 0.9955215176415282, 0.0044784823584557674, 1.6204320801536055E-14]
+[0.0, 0.9993084207174197, 6.915792825781358E-4, 2.222252400365488E-15]
+[0.0, 0.9911093917270507, 0.008890608272888893, 6.058381292732797E-14]
+[0.0, 0.9985498834549938, 0.0014501165449916302, 1.465160353625109E-14]
+[0.0, 0.9998386655691961, 1.6133443080375653E-4, 9.614772566311996E-17]
+[0.0, 0.9847580622351955, 0.015241937762277972, 2.52658274242985E-12]
+[0.0, 0.9975288877133629, 0.0024711122865651997, 7.183198231997113E-14]
+[0.0, 0.98426772182844, 0.015732278171201177, 3.5885684925191495E-13]
+[0.0, 0.9951262938147029, 0.004873706185103284, 1.9392730015574358E-13]
+[0.0, 0.9974700085348233, 0.0025299914651693584, 7.355459052346989E-15]
+[0.0, 0.9965949204436243, 0.003405079556366835, 8.928929744112919E-15]
+[0.0, 0.9970241388871911, 0.0029758611127558756, 5.311509596397438E-14]
+[0.0, 0.9939811530340449, 0.006018846965826611, 1.283757288823009E-13]
+[0.0, 0.9880192761301445, 0.011980723869648751, 2.065657131232572E-13]
+[0.0, 0.9998688688133242, 1.3113118667585423E-4, 2.856424790544176E-17]
+[0.0, 0.9997846448093242, 2.1535519067583398E-4, 4.0055820554061903E-17]
+[0.0, 0.9932394745323204, 0.006760525467592444, 8.71682981708591E-14]
+[0.0, 0.9963510355968378, 0.0036489644031525233, 9.718812803280444E-15]
+[0.0, 0.9958474988312674, 0.004152501168728628, 3.948327488249725E-15]
+[0.0, 0.9995261359569318, 4.73864043067744E-4, 4.1289475139686807E-16]
+[0.0, 0.9978801981639176, 0.002119801836053271, 2.9006086084687233E-14]
+[0.0, 0.9969696054110023, 0.0030303945889845166, 1.3145067837592893E-14]
+[0.0, 0.9984973212176447, 0.0015026787823495817, 5.860751675672395E-15]
+[0.0, 0.9230634274618519, 0.07693657252135745, 1.679055049919341E-11]
+[0.0, 0.9991270058428275, 8.729941571659106E-4, 6.69989461699283E-15]
+[0.0, 0.994343346026573, 0.005656653972492217, 9.347490968314634E-13]
+[0.0, 0.9983308727891536, 0.0016691272107856687, 6.066690943346501E-14]
+[0.0, 0.9906053826053467, 0.009394617394365689, 2.874783613852964E-13]
+[0.0, 0.9994051189718244, 5.948810281744814E-4, 1.2017288921739112E-15]
+[0.0, 0.998290765968156, 0.0017092340318284982, 1.555380862526547E-14]
+[0.0, 0.9986444394111714, 0.0013555605888266084, 1.9781905348235194E-15]
+[0.0, 0.996862909632446, 0.003137090367540339, 1.3714387081016445E-14]
+[1.0, 2.3737258340922007E-4, 0.9920888936377737, 0.007673733778817162]
+[1.0, 0.0011359980925831552, 0.9829636308352996, 0.015900371072117177]
+[1.0, 1.0449254396304994E-4, 0.9436880250220233, 0.056207482434013634]
+[1.0, 8.39822767606033E-4, 0.9843649440634956, 0.014795233168898192]
+[1.0, 1.2152699277288232E-4, 0.9361033963239962, 0.06377507668323087]
+[1.0, 0.0021863832820463785, 0.978088119411165, 0.0197254973067885]
+[1.0, 0.0012139139759576735, 0.9335651879115218, 0.06522089811252066]
+[1.0, 0.0419540077872531, 0.9579428668626017, 1.0312535014500176E-4]
+[1.0, 2.793954588092634E-4, 0.9915557783484369, 0.008164826192753829]
+[1.0, 0.009366025962453811, 0.9803476718565266, 0.010286302181019683]
+[1.0, 0.00422947781250348, 0.9951025809773127, 6.679412101838515E-4]
+[1.0, 0.0026996875739485294, 0.9820941334711174, 0.015206178954934178]
+[1.0, 3.5722162609382475E-4, 0.9987615511725312, 8.812272013750565E-4]
+[1.0, 6.419578174229608E-4, 0.9517663546358988, 0.04759168754667817]
+[1.0, 0.016626242200057328, 0.9828881284134628, 4.8562938647990587E-4]
+[1.0, 5.21593546311477E-4, 0.9950593954375281, 0.004419011016160542]
+[1.0, 0.003635242500999334, 0.931105743482407, 0.06525901401659365]
+[1.0, 0.0047961535485430765, 0.994821617107219, 3.8222934423800896E-4]
+[1.0, 1.688705666500541E-5, 0.7331870686580153, 0.2667960442853197]
+[1.0, 0.003327935948924622, 0.9957569697735823, 9.150942774929203E-4]
+[2.0, 5.193790275870363E-4, 0.4555887238726096, 0.5438918970998033]
+[1.0, 0.0016151591304566708, 0.9965718093835577, 0.0018130314859856132]
+[1.0, 2.2559071253740876E-5, 0.6034658259765083, 0.39651161495223797]
+[1.0, 7.735426605238897E-4, 0.9873383983885669, 0.0118880589509093]
+[1.0, 7.369013858687694E-4, 0.9961067664586088, 0.00315633215552236]
+[1.0, 4.343385240410304E-4, 0.992986171887975, 0.006579489587984065]
+[1.0, 5.6624760717292834E-5, 0.9564724497684658, 0.04347092547081688]
+[1.0, 3.159082985835274E-5, 0.5508915471163474, 0.44907686205379427]
+[1.0, 8.235380980646436E-4, 0.9425896095131215, 0.05658685238881397]
+[1.0, 0.009582674719357424, 0.990363396187608, 5.392909303458656E-5]
+[1.0, 0.003214747215296974, 0.9958628985175881, 9.223542671147885E-4]
+[1.0, 0.005002134786335749, 0.9947335905266799, 2.6427468698434885E-4]
+[1.0, 0.0035503687994753405, 0.9954818833334347, 9.67747867090111E-4]
+[2.0, 3.038751128959944E-5, 0.2737034464142567, 0.7262661660744536]
+[1.0, 0.0060408821828637875, 0.9139782727067634, 0.07998084511037284]
+[1.0, 0.005757219986905609, 0.9621966298433439, 0.0320461501697506]
+[1.0, 2.4284953606885763E-4, 0.9669474126441001, 0.03280973781983085]
+[1.0, 5.6192385684612204E-5, 0.9710941054843388, 0.028849702129976566]
+[1.0, 0.012501999188211226, 0.984906429135615, 0.0025915716761739063]
+[1.0, 0.002052672106399782, 0.9896049415720769, 0.008342386321523308]
+[1.0, 0.002388130371391583, 0.9849280255291474, 0.012683844099460984]
+[1.0, 0.0011859013160251564, 0.9741718400430543, 0.02464225864092062]
+[1.0, 0.0019684019291546354, 0.9961173633523933, 0.0019142347184522084]
+[1.0, 0.021128825398678216, 0.9787452647209759, 1.2590988034593418E-4]
+[1.0, 0.0028580471835154453, 0.9879795525974273, 0.009162400219057301]
+[1.0, 0.011199267732995146, 0.987339042419485, 0.001461689847519873]
+[1.0, 0.005351619547265066, 0.9900397446343987, 0.0046086358183361625]
+[1.0, 0.0012458833539609377, 0.9948183511656867, 0.0039357654803524374]
+[1.0, 0.044417904755865954, 0.9555373139259348, 4.4781318199087464E-5]
+[1.0, 0.003980078563979929, 0.9918555485984235, 0.004164372837596569]
+[2.0, 5.253921989094925E-10, 3.917844849436808E-5, 0.9999608210261133]
+[2.0, 1.742112623952287E-6, 0.02259248807423019, 0.9774057698131459]
+[2.0, 2.972006294683891E-9, 0.0018173516687317588, 0.998182645359262]
+[2.0, 7.561230330804004E-7, 0.023220436905909, 0.976778806971058]
+[2.0, 4.010698144174694E-9, 5.877231099291545E-4, 0.9994122728793726]
+[2.0, 3.204948985540653E-11, 2.0344720692721955E-4, 0.9997965527610233]
+[2.0, 3.217112339494918E-4, 0.21789497318431597, 0.7817833155817345]
+[2.0, 3.875314290131039E-9, 0.004606822628125995, 0.9953931734965599]
+[2.0, 7.591026835375579E-9, 0.005291009759112349, 0.9947089826498609]
+[2.0, 7.030138058429411E-10, 1.71059566895087E-4, 0.9998289397300911]
+[2.0, 6.950569650176702E-6, 0.08308558470728847, 0.9169074647230613]
+[2.0, 2.3861078978474606E-7, 0.020114799161093773, 0.9798849622281165]
+[2.0, 4.028114031587584E-8, 0.006229467634981506, 0.9937704920838781]
+[2.0, 2.57017865798613E-7, 0.007241294152772684, 0.9927584488293616]
+[2.0, 1.1603762516228188E-8, 4.260509892289183E-4, 0.9995739374070085]
+[2.0, 9.417494881638644E-8, 0.0028255687753475822, 0.9971743370497036]
+[2.0, 1.923998394358469E-6, 0.055421196905738, 0.9445768790958676]
+[2.0, 1.7886099780423162E-9, 6.586546553288446E-4, 0.9993413435560613]
+[2.0, 2.899063100409519E-14, 3.975412162470039E-6, 0.9999960245878085]
+[2.0, 4.435339720864727E-6, 0.23636123078893864, 0.7636343338713404]
+[2.0, 5.111175765011423E-9, 0.0010265059943631223, 0.998973488894461]
+[2.0, 4.557282601326357E-6, 0.022489547881801922, 0.9775058948355968]
+[2.0, 1.1742919910999774E-11, 2.028122146709921E-4, 0.9997971877735861]
+[2.0, 6.415214007979874E-6, 0.17204783311541544, 0.8279457516705766]
+[2.0, 1.441820439876566E-7, 0.006056942078486189, 0.9939429137394697]
+[2.0, 1.9949116842101748E-7, 0.031002211275454952, 0.9689975892333765]
+[2.0, 2.353623992007988E-5, 0.2687962767622606, 0.7311801869978194]
+[2.0, 6.790320617185304E-5, 0.28376504490155374, 0.7161670518922744]
+[2.0, 1.001666516091826E-8, 0.0015211150215214606, 0.9984788749618133]
+[2.0, 1.149899546431686E-6, 0.17904098555392473, 0.8209578645465289]
+[2.0, 1.4826518475504287E-9, 0.0035916339134616456, 0.9964083646038865]
+[2.0, 6.57369675633502E-8, 0.01459000728008265, 0.9854099269829498]
+[2.0, 3.1634689407872872E-9, 6.465171922358903E-4, 0.9993534796442952]
+[1.0, 6.590043226267748E-5, 0.6230571008290332, 0.3768769987387041]
+[2.0, 9.415312064529413E-6, 0.1973837694064133, 0.8026068152815222]
+[2.0, 4.04899363685433E-11, 2.914938127823631E-4, 0.9997085061467276]
+[2.0, 2.9875072002741936E-8, 5.91407674822975E-4, 0.999408562450105]
+[2.0, 4.614534960582518E-6, 0.06551955965226777, 0.9344758258127717]
+[2.0, 1.2404659951572032E-4, 0.3442030365449645, 0.6556729168555199]
+[2.0, 1.2249701584624956E-7, 0.013656924437329576, 0.9863429530656546]
+[2.0, 1.8009824018135346E-9, 3.8733524743669395E-4, 0.999612662951581]
+[2.0, 6.172291379481668E-8, 0.00803633160428406, 0.991963606672802]
+[2.0, 1.742112623952287E-6, 0.02259248807423019, 0.9774057698131459]
+[2.0, 2.0280261956052507E-9, 4.19417579803993E-4, 0.9995805803921698]
+[2.0, 1.4378194710783333E-9, 1.9813309382031176E-4, 0.9998018654683601]
+[2.0, 2.356982195824312E-8, 0.003271707386699527, 0.9967282690434786]
+[2.0, 3.185026641778725E-7, 0.03235032725651199, 0.9676493542408238]
+[2.0, 9.866449523793526E-7, 0.03319067809811433, 0.9668083352569332]
+[2.0, 3.230373781220064E-7, 0.0027257791168188886, 0.997273897845803]
+[2.0, 3.824108874591791E-5, 0.12647835360995457, 0.8734834053012995]

--- a/mojo-data/mojos/glm/missing/v1.00/glm_v1.00_missing_scores1.txt
+++ b/mojo-data/mojos/glm/missing/v1.00/glm_v1.00_missing_scores1.txt
@@ -1,40 +1,40 @@
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
+[15.392600109448491, 0.0]
+[8.349928094716919, 0.0]
+[17.419991910204793, 0.0]
+[10.660988192547489, 0.0]
+[18.890417095582954, 0.0]
+[14.945253858510128, 0.0]
+[21.155204502893874, 0.0]
+[16.653074650442907, 0.0]
+[17.911681154690307, 0.0]
+[15.55556587278416, 0.0]
+[19.81286015485467, 0.0]
+[20.945253858510128, 0.0]
+[19.587323701271536, 0.0]
+[20.747109205683298, 0.0]
+[29.39260010944849, 0.0]
+[24.653074650442907, 0.0]
+[31.022810799238414, 0.0]
+[26.28328534023283, 0.0]
+[27.653074650442907, 0.0]
+[26.747109205683298, 0.0]
+[29.41567904388829, 0.0]
+[36.68477931751571, 0.0]
+[31.54807274754375, 0.0]
+[38.392600109448495, 0.0]
+[31.21753439106146, 0.0]
+[40.55238561386025, 0.0]
+[33.48232179837238, 0.0]
+[35.45535041448025, 0.0]
+[36.19056300716933, 0.0]
+[44.392600109448495, 0.0]
+[39.68046645119921, 0.0]
+[38.587323701271536, 0.0]
+[47.41999191020479, 0.0]
+[48.28759820654933, 0.0]
+[43.01849793292191, 0.0]
+[50.392600109448495, 0.0]
+[45.91168115469031, 0.0]
+[46.94525385851013, 0.0]
+[46.058169303513864, 0.0]
+[46.587323701271536, 0.0]

--- a/mojo-data/mojos/glm/names/v1.00/glm_v1.00_names_scores1.txt
+++ b/mojo-data/mojos/glm/names/v1.00/glm_v1.00_names_scores1.txt
@@ -1,2558 +1,2558 @@
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
+[0.0, 0.7006485816399288, 0.2993514183600712]
+[1.0, 0.544235026871009, 0.455764973128991]
+[1.0, 0.2423945486191229, 0.7576054513808771]
+[1.0, 0.1381290665179803, 0.8618709334820197]
+[1.0, 0.04101508946406929, 0.9589849105359307]
+[1.0, 0.020932855567361575, 0.9790671444326384]
+[1.0, 0.005652794790430127, 0.9943472052095699]
+[1.0, 0.0028305607599854454, 0.9971694392400146]
+[1.0, 7.427940697080082E-4, 0.999257205930292]
+[1.0, 3.7545487893997365E-4, 0.99962454512106]
+[1.0, 1.4025602286860117E-4, 0.9998597439771314]
+[1.0, 3.7490559438912996E-5, 0.9999625094405611]
+[1.0, 1.8500774073282322E-5, 0.9999814992259267]
+[1.0, 6.887661786358912E-6, 0.9999931123382136]
+[1.0, 1.8350309827219746E-6, 0.9999981649690173]
+[1.0, 9.112202162819827E-7, 0.9999990887797837]
+[1.0, 3.3818156564002777E-7, 0.9999996618184344]
+[1.0, 9.060857641962627E-8, 0.9999999093914236]
+[1.0, 4.446991574980075E-8, 0.9999999555300843]
+[1.0, 1.6520380397011536E-8, 0.9999999834796196]
+[1.0, 4.403742037695224E-9, 0.999999995596258]
+[1.0, 2.1657227122773293E-9, 0.9999999978342773]
+[1.0, 8.089071634742595E-10, 0.9999999991910928]
+[1.0, 2.1394952476327944E-10, 0.9999999997860505]
+[1.0, 1.0499823233089955E-10, 0.9999999998950018]
+[1.0, 3.9459546741227314E-11, 0.9999999999605405]
+[1.0, 1.4659162772545642E-11, 0.9999999999853408]
+[1.0, 3.901989842347575E-12, 0.999999999996098]
+[1.0, 1.923128323255696E-12, 0.9999999999980769]
+[1.0, 7.167599846980011E-13, 0.9999999999992832]
+[1.0, 1.9628743075372768E-13, 0.9999999999998037]
+[1.0, 9.303668946358812E-14, 0.999999999999907]
+[1.0, 3.4861002973229915E-14, 0.9999999999999651]
+[1.0, 1.2878587085651816E-14, 0.9999999999999871]
+[1.0, 3.552713678800501E-15, 0.9999999999999964]
+[1.0, 1.7763568394002505E-15, 0.9999999999999982]
+[1.0, 6.661338147750939E-16, 0.9999999999999993]
+[1.0, 2.220446049250313E-16, 0.9999999999999998]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]
+[1.0, 0.0, 1.0]

--- a/mojo-data/mojos/glm/stars/v1.00/glm_v1.00_stars_scores1.txt
+++ b/mojo-data/mojos/glm/stars/v1.00/glm_v1.00_stars_scores1.txt
@@ -1,300 +1,300 @@
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
+[321.6872427083736, 0.0]
+[365.2749430925191, 0.0]
+[298.43968028439576, 0.0]
+[342.5398531246754, 0.0]
+[338.89523550890675, 0.0]
+[346.72952021316075, 0.0]
+[374.19819790368507, 0.0]
+[328.26555956604676, 0.0]
+[361.4251495188642, 0.0]
+[370.78986250960145, 0.0]
+[373.92178145531875, 0.0]
+[336.9233353284481, 0.0]
+[371.0851539076818, 0.0]
+[356.643184738454, 0.0]
+[378.07142723140345, 0.0]
+[371.75624582574636, 0.0]
+[351.28612827567616, 0.0]
+[347.5074412159245, 0.0]
+[392.9462082074498, 0.0]
+[377.17906648444813, 0.0]
+[363.7217731660185, 0.0]
+[379.59019190602186, 0.0]
+[360.5081816472058, 0.0]
+[385.8844892458271, 0.0]
+[368.4708681798867, 0.0]
+[378.0044232129909, 0.0]
+[373.36162656037516, 0.0]
+[373.48761422601984, 0.0]
+[394.9904596585172, 0.0]
+[374.827904431591, 0.0]
+[392.77671878021283, 0.0]
+[372.9642438556197, 0.0]
+[391.530102696117, 0.0]
+[378.9956395687911, 0.0]
+[397.1135803256169, 0.0]
+[404.0071269893845, 0.0]
+[384.70183231262513, 0.0]
+[380.6076029195397, 0.0]
+[392.0858786983519, 0.0]
+[399.63768680977216, 0.0]
+[381.98581975282565, 0.0]
+[398.2875867869211, 0.0]
+[386.39501175662315, 0.0]
+[393.4221212409935, 0.0]
+[386.20319968972336, 0.0]
+[403.00516924570206, 0.0]
+[395.2359117465518, 0.0]
+[403.0462683973124, 0.0]
+[393.8749365775245, 0.0]
+[388.3576690185573, 0.0]
+[392.7826226445765, 0.0]
+[400.66312622662645, 0.0]
+[391.3478417089833, 0.0]
+[395.720041386844, 0.0]
+[403.303108154052, 0.0]
+[415.6020897571255, 0.0]
+[401.0457209975172, 0.0]
+[406.3295999944719, 0.0]
+[392.6743774293359, 0.0]
+[401.41079524444507, 0.0]
+[414.1495345818449, 0.0]
+[393.7365546950168, 0.0]
+[420.39947314192796, 0.0]
+[409.0660250595833, 0.0]
+[429.7070460937779, 0.0]
+[425.1233606774594, 0.0]
+[405.05554815619195, 0.0]
+[425.40612767146996, 0.0]
+[407.8968584752464, 0.0]
+[434.23403125795073, 0.0]
+[419.8037965954968, 0.0]
+[416.64611519519895, 0.0]
+[433.826669926484, 0.0]
+[409.1393749692316, 0.0]
+[428.9731873859472, 0.0]
+[430.7350044963487, 0.0]
+[415.42636318386457, 0.0]
+[435.1357547418545, 0.0]
+[431.2277553714015, 0.0]
+[418.86533490312047, 0.0]
+[428.02094367247804, 0.0]
+[439.0014530694617, 0.0]
+[438.64237859859406, 0.0]
+[423.6818009771118, 0.0]
+[424.07929428880885, 0.0]
+[424.3050089469252, 0.0]
+[433.7533629977451, 0.0]
+[458.41661799250926, 0.0]
+[422.2024505305612, 0.0]
+[446.1031563520104, 0.0]
+[428.0438505432666, 0.0]
+[435.4037976158197, 0.0]
+[440.76782996497997, 0.0]
+[446.8064627798469, 0.0]
+[448.22611183452176, 0.0]
+[431.2794304994556, 0.0]
+[453.0881617396279, 0.0]
+[460.495768044154, 0.0]
+[452.2381399847724, 0.0]
+[445.6618245454523, 0.0]
+[439.26772186544383, 0.0]
+[447.6519104397668, 0.0]
+[439.2076465916235, 0.0]
+[438.9944056402903, 0.0]
+[443.69668405506593, 0.0]
+[455.4376332012833, 0.0]
+[452.1950151989161, 0.0]
+[451.9741598197632, 0.0]
+[448.8169322971582, 0.0]
+[438.51154930221946, 0.0]
+[466.3854138050775, 0.0]
+[466.2324001110419, 0.0]
+[455.0666031240974, 0.0]
+[464.7342452347221, 0.0]
+[470.415452559442, 0.0]
+[476.8624278516608, 0.0]
+[465.7863229341743, 0.0]
+[470.49639828498766, 0.0]
+[462.6771179740858, 0.0]
+[458.0887047212776, 0.0]
+[474.52034457396127, 0.0]
+[452.6051349570796, 0.0]
+[485.0521502035483, 0.0]
+[459.32371331345985, 0.0]
+[461.9607253411161, 0.0]
+[464.8409869005421, 0.0]
+[469.3981006262393, 0.0]
+[479.8010529903924, 0.0]
+[479.3292349669372, 0.0]
+[470.0635279263955, 0.0]
+[486.6356211346917, 0.0]
+[476.19529407438864, 0.0]
+[460.8130350008407, 0.0]
+[458.6956622118127, 0.0]
+[488.3881246614454, 0.0]
+[472.062418329871, 0.0]
+[486.8403479851846, 0.0]
+[473.37002414789015, 0.0]
+[470.01226786185947, 0.0]
+[498.96306288542405, 0.0]
+[497.0329772994023, 0.0]
+[490.4315502338899, 0.0]
+[493.8929246926752, 0.0]
+[484.3933420117971, 0.0]
+[473.7727287534084, 0.0]
+[482.947357159813, 0.0]
+[490.70758571835626, 0.0]
+[495.0117668244171, 0.0]
+[494.7349841831207, 0.0]
+[496.6093628847312, 0.0]
+[495.2655631316644, 0.0]
+[503.3350611163269, 0.0]
+[497.3598073431891, 0.0]
+[507.62762909747516, 0.0]
+[508.8041589024404, 0.0]
+[513.4866491256339, 0.0]
+[506.85338349948245, 0.0]
+[512.2375686004739, 0.0]
+[506.4532976380142, 0.0]
+[523.4741755860354, 0.0]
+[506.5667930302504, 0.0]
+[507.1518452826711, 0.0]
+[501.5616353513107, 0.0]
+[519.8697599913168, 0.0]
+[511.4226972914207, 0.0]
+[517.5784714654617, 0.0]
+[514.3475321296755, 0.0]
+[505.5596068843258, 0.0]
+[511.30628054257227, 0.0]
+[534.4332192235534, 0.0]
+[507.384964651216, 0.0]
+[512.780219326568, 0.0]
+[515.2898967484932, 0.0]
+[526.1001421979065, 0.0]
+[533.0483154754622, 0.0]
+[520.3411807963025, 0.0]
+[530.1969108259916, 0.0]
+[527.9634632838354, 0.0]
+[545.5079786641115, 0.0]
+[529.3013547008452, 0.0]
+[545.1557616555698, 0.0]
+[531.6075917649664, 0.0]
+[519.4455405606786, 0.0]
+[532.7753333440171, 0.0]
+[542.6045546948815, 0.0]
+[532.7473531950159, 0.0]
+[525.1784467806226, 0.0]
+[531.3430743407569, 0.0]
+[531.4976876367604, 0.0]
+[532.0033773333193, 0.0]
+[542.61091038566, 0.0]
+[531.7836313141111, 0.0]
+[530.4675770577112, 0.0]
+[524.9100076438324, 0.0]
+[549.6043585022804, 0.0]
+[531.3139648137637, 0.0]
+[550.9622995463093, 0.0]
+[543.5601207639866, 0.0]
+[545.7039538263409, 0.0]
+[549.0048207902723, 0.0]
+[552.3913852211315, 0.0]
+[531.761049562525, 0.0]
+[551.528309233982, 0.0]
+[548.7750090588462, 0.0]
+[550.2527966794066, 0.0]
+[538.8527619644694, 0.0]
+[530.5703384613422, 0.0]
+[553.9060417868591, 0.0]
+[544.802731603258, 0.0]
+[551.5303106950878, 0.0]
+[552.3427663694853, 0.0]
+[541.6352096973196, 0.0]
+[566.2045141329563, 0.0]
+[551.6714829856526, 0.0]
+[547.4201845597659, 0.0]
+[569.0783905077443, 0.0]
+[555.5702252645146, 0.0]
+[564.5870041968612, 0.0]
+[563.0487110586512, 0.0]
+[558.9715443886608, 0.0]
+[569.4487196271904, 0.0]
+[575.2640673012577, 0.0]
+[568.5845296313734, 0.0]
+[561.7546303518238, 0.0]
+[576.8300965611288, 0.0]
+[567.5282099662859, 0.0]
+[570.6957377331169, 0.0]
+[578.0935434918354, 0.0]
+[566.4732177539881, 0.0]
+[573.5602077256128, 0.0]
+[583.4760397649815, 0.0]
+[585.0625204778592, 0.0]
+[581.8722329991465, 0.0]
+[582.6559871905695, 0.0]
+[594.4846393272915, 0.0]
+[580.5750625108396, 0.0]
+[585.0074437362118, 0.0]
+[573.421672931471, 0.0]
+[574.5555354616631, 0.0]
+[580.6307638559495, 0.0]
+[579.4847423438559, 0.0]
+[584.8643354334326, 0.0]
+[586.1811444027796, 0.0]
+[604.1600711559643, 0.0]
+[595.3237838374879, 0.0]
+[602.6835223604612, 0.0]
+[579.2398773800235, 0.0]
+[590.9509713428321, 0.0]
+[578.8065056908463, 0.0]
+[602.5693401796415, 0.0]
+[586.3417396322824, 0.0]
+[592.5432853757327, 0.0]
+[610.7348000257474, 0.0]
+[609.3530797092255, 0.0]
+[599.5182105761701, 0.0]
+[610.1075773196404, 0.0]
+[598.1765075568519, 0.0]
+[603.7930032285853, 0.0]
+[607.9943559664582, 0.0]
+[611.8199430345452, 0.0]
+[600.7203757137513, 0.0]
+[591.1935961937857, 0.0]
+[606.5049769112586, 0.0]
+[596.8514649827603, 0.0]
+[617.2537320159654, 0.0]
+[588.401500949369, 0.0]
+[608.3362735491015, 0.0]
+[618.4963609858793, 0.0]
+[614.9811957346407, 0.0]
+[608.5336099073147, 0.0]
+[610.8862661079437, 0.0]
+[627.1976009083742, 0.0]
+[590.8092251516005, 0.0]
+[612.6412590654477, 0.0]
+[624.6736174595895, 0.0]
+[613.8225931086765, 0.0]
+[612.323891574269, 0.0]
+[641.139875835876, 0.0]
+[616.4523066741738, 0.0]
+[589.5138289348141, 0.0]
+[639.7932636293137, 0.0]
+[631.6885443513372, 0.0]
+[626.3738005979814, 0.0]
+[630.3768945020132, 0.0]
+[625.6285351780326, 0.0]
+[641.2656687280698, 0.0]
+[618.9310776437228, 0.0]
+[625.9948454980142, 0.0]
+[634.2833622764631, 0.0]
+[628.0180762298476, 0.0]
+[615.0146043588163, 0.0]
+[632.0308344713949, 0.0]
+[655.6309089367952, 0.0]
+[641.5893692788661, 0.0]
+[631.0866452617895, 0.0]
+[637.0098419174078, 0.0]
+[643.7063415283303, 0.0]
+[637.9304769117012, 0.0]
+[638.8903082545391, 0.0]
+[636.4086019731376, 0.0]

--- a/mojo-data/mojos/glm/titanic/v1.00/glm_v1.00_titanic_scores1.txt
+++ b/mojo-data/mojos/glm/titanic/v1.00/glm_v1.00_titanic_scores1.txt
@@ -1,1309 +1,1309 @@
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
-java.lang.UnsupportedOperationException: `offset` column is not supported
+[0.0, 0.5831825051815719, 0.2544108434341397, 0.126239119129922, 0.012055844084788851, 0.00904188306359164, 0.00904188306359164, 0.0030139610211972123, 0.0030139610211972123]
+[0.0, 0.4110022045560327, 0.3014373720454475, 0.2447075098632228, 0.014284304511765723, 0.010713228383824294, 0.010713228383824294, 0.00357107612794143, 0.00357107612794143]
+[1.0, 0.33224654445170826, 0.3432928376294979, 0.27565745131606195, 0.016267722200910665, 0.012200791650683001, 0.012200791650683001, 0.004066930550227665, 0.004066930550227665]
+[0.0, 0.5832328047281046, 0.23848238829695778, 0.14438169437800352, 0.011301037532311337, 0.008475778149233506, 0.008475778149233506, 0.002825259383077834, 0.002825259383077834]
+[0.0, 0.46340262613311406, 0.3016464464468649, 0.1920682914678068, 0.01429421198407148, 0.010720658988053612, 0.010720658988053612, 0.0035735529960178695, 0.0035735529960178695]
+[0.0, 0.9067502957282673, 0.060103417591101715, 0.024601869842964016, 0.00284813894588914, 0.0021361042094168556, 0.0021361042094168556, 7.12034736472285E-4, 7.12034736472285E-4]
+[0.0, 0.7669275229340765, 0.1478855617669674, 0.06416322089598323, 0.007007898134324264, 0.005255923600743199, 0.005255923600743199, 0.0017519745335810657, 0.0017519745335810657]
+[0.0, 0.9031366413291373, 0.060907757954399996, 0.027296837313843525, 0.002886254467539603, 0.0021646908506547024, 0.0021646908506547024, 7.215636168849006E-4, 7.215636168849006E-4]
+[0.0, 0.5914098016755844, 0.23567077592331503, 0.1394160139985233, 0.01116780280085904, 0.008375852100644282, 0.008375852100644282, 0.0027919507002147595, 0.0027919507002147595]
+[0.0, 0.9340980119846486, 0.044929843458198615, 0.014584832049072861, 0.0021291041693599676, 0.001596828127019976, 0.001596828127019976, 5.322760423399918E-4, 5.322760423399918E-4]
+[0.0, 0.5660345888436321, 0.2626335558101649, 0.1339953665683493, 0.012445496259284651, 0.00933412219446349, 0.00933412219446349, 0.0031113740648211624, 0.0031113740648211624]
+[1.0, 0.3140699310977124, 0.37570592909048817, 0.2568130661125977, 0.01780369123306734, 0.013352768424800508, 0.013352768424800508, 0.004450922808266834, 0.004450922808266834]
+[0.0, 0.7492907927012517, 0.15069432506820288, 0.07859188866280002, 0.007140997855915093, 0.005355748391936321, 0.005355748391936321, 0.001785249463978773, 0.001785249463978773]
+[0.0, 0.7469596426752282, 0.15305161284956087, 0.0782306343663849, 0.007252703369608681, 0.0054395275272065115, 0.0054395275272065115, 0.00181317584240217, 0.00181317584240217]
+[0.0, 0.9512811814433231, 0.03386589964307498, 0.010038477826380522, 0.0016048136957405742, 0.0012036102718054307, 0.0012036102718054307, 4.012034239351435E-4, 4.012034239351435E-4]
+[0.0, 0.8656342949435419, 0.08225325560084336, 0.040419169268285496, 0.0038977600624430925, 0.0029233200468323202, 0.0029233200468323202, 9.744400156107731E-4, 9.744400156107731E-4]
+[0.0, 0.5893972037513172, 0.24673950412826448, 0.1287863321389715, 0.011692319993815559, 0.008769239995361671, 0.008769239995361671, 0.0029230799984538893, 0.0029230799984538893]
+[0.0, 0.6443705261916562, 0.2303725485093287, 0.09250672304244853, 0.010916734085522193, 0.008187550564141647, 0.008187550564141647, 0.0027291835213805477, 0.0027291835213805477]
+[0.0, 0.7750547933227466, 0.1385744702644273, 0.06667072459230826, 0.006566670606839237, 0.004925002955129429, 0.004925002955129429, 0.001641667651709809, 0.001641667651709809]
+[0.0, 0.8455601924622935, 0.0962689219710984, 0.04448511143259748, 0.004561924711336906, 0.00342144353350268, 0.00342144353350268, 0.0011404811778342263, 0.0011404811778342263]
+[0.0, 0.7522066495296285, 0.14524322801565134, 0.08190206727328182, 0.006882685060479446, 0.0051620137953595855, 0.0051620137953595855, 0.0017206712651198612, 0.0017206712651198612]
+[0.0, 0.7269148015244099, 0.1653101072036037, 0.08427429015221455, 0.00783360037325728, 0.005875200279942962, 0.005875200279942962, 0.0019584000933143197, 0.0019584000933143197]
+[0.0, 0.8516863685802395, 0.08971372016740643, 0.04584603714850175, 0.004251291367950755, 0.0031884685259630664, 0.0031884685259630664, 0.0010628228419876885, 0.0010628228419876885]
+[0.0, 0.6307003709853214, 0.23411637568390503, 0.1019008214401885, 0.011094143963528326, 0.008320607972646245, 0.008320607972646245, 0.002773535990882081, 0.002773535990882081]
+[0.0, 0.5674684579517463, 0.2639983709880918, 0.13100265754538032, 0.01251017117159396, 0.009382628378695471, 0.009382628378695471, 0.0031275427928984896, 0.0031275427928984896]
+[0.0, 0.8518660098741342, 0.08932565609700625, 0.04610962785571917, 0.004232902057713415, 0.003174676543285062, 0.003174676543285062, 0.0010582255144283535, 0.0010582255144283535]
+[0.0, 0.6434509755150349, 0.20045249124546516, 0.1275998235681398, 0.009498903223786648, 0.007124177417839988, 0.007124177417839988, 0.0023747258059466617, 0.0023747258059466617]
+[0.0, 0.5208015656398958, 0.2635227871130413, 0.17821274364586973, 0.012487634533731145, 0.00936572590029836, 0.00936572590029836, 0.003121908633432786, 0.003121908633432786]
+[0.0, 0.7192351412477431, 0.1744893464559598, 0.08146977296222262, 0.008268579778024778, 0.0062014348335185845, 0.0062014348335185845, 0.002067144944506194, 0.002067144944506194]
+[0.0, 0.8600266976332889, 0.08519503882228491, 0.04266677382596768, 0.004037163239486249, 0.003027872429614687, 0.003027872429614687, 0.001009290809871562, 0.001009290809871562]
+[0.0, 0.8957729641223878, 0.06663794443526908, 0.02811571376631952, 0.0031577925586744886, 0.0023683444190058666, 0.0023683444190058666, 7.89448139668622E-4, 7.89448139668622E-4]
+[0.0, 0.8874079892615527, 0.07099594826569412, 0.03150314263424166, 0.0033643066128371127, 0.002523229959627835, 0.002523229959627835, 8.410766532092781E-4, 8.410766532092781E-4]
+[0.0, 0.6559389348140126, 0.21065640063063715, 0.10345734760315577, 0.009982438984064859, 0.007486829238048645, 0.007486829238048645, 0.0024956097460162143, 0.0024956097460162143]
+[0.0, 0.8944107757572939, 0.0698241497035424, 0.025838739826192593, 0.003308778237657075, 0.002481583678242807, 0.002481583678242807, 8.271945594142687E-4, 8.271945594142687E-4]
+[0.0, 0.8945163505729579, 0.06688781635115504, 0.029086933130233784, 0.003169633315217825, 0.0023772249864133692, 0.0023772249864133692, 7.924083288044561E-4, 7.924083288044561E-4]
+[0.0, 0.5960597144172258, 0.2581891870254965, 0.10904642974904477, 0.01223488960274434, 0.009176167202058256, 0.009176167202058256, 0.0030587224006860844, 0.0030587224006860844]
+[0.0, 0.7570140553532413, 0.14512805018645833, 0.07722621317942412, 0.006877227093625391, 0.005157920320219045, 0.005157920320219045, 0.0017193067734063475, 0.0017193067734063475]
+[0.0, 0.86518585889618, 0.08252769981563114, 0.040554145586204814, 0.003910765233994715, 0.002933073925496037, 0.002933073925496037, 9.776913084986786E-4, 9.776913084986786E-4]
+[0.0, 0.8899778551541725, 0.0695708863013282, 0.030560928241343512, 0.0032967767677186755, 0.0024725825757890073, 0.0024725825757890073, 8.241941919296688E-4, 8.241941919296688E-4]
+[0.0, 0.8935076913580468, 0.0686368794131039, 0.028097879131912525, 0.0032525166989788522, 0.002439387524234142, 0.002439387524234142, 8.13129174744713E-4, 8.13129174744713E-4]
+[0.0, 0.8555311026287727, 0.0884363753852307, 0.043460237660259284, 0.00419076144191238, 0.003143071081434286, 0.003143071081434286, 0.0010476903604780948, 0.0010476903604780948]
+[0.0, 0.8595683958047796, 0.08954147521000567, 0.03816074155405437, 0.0042431291437201165, 0.003182346857790088, 0.003182346857790088, 0.0010607822859300291, 0.0010607822859300291]
+[0.0, 0.6249402197837155, 0.22075391601567246, 0.12292306514220054, 0.010460933019470452, 0.00784569976460284, 0.00784569976460284, 0.002615233254867613, 0.002615233254867613]
+[0.0, 0.8670687627256138, 0.08833180122987816, 0.03204201818077239, 0.004185805954578543, 0.0031393544659339074, 0.0031393544659339074, 0.0010464514886446355, 0.0010464514886446355]
+[0.0, 0.7475092659599427, 0.15963793086165465, 0.07015836949969866, 0.0075648112262346676, 0.005673608419676002, 0.005673608419676002, 0.0018912028065586667, 0.0018912028065586667]
+[0.0, 0.9008090830641401, 0.06341877585499063, 0.026756406569295465, 0.003005244837191324, 0.0022539336278934933, 0.0022539336278934933, 7.51311209297831E-4, 7.51311209297831E-4]
+[0.0, 0.861956374306249, 0.08450414620798691, 0.04152620838320457, 0.0040044237008530804, 0.003003317775639811, 0.003003317775639811, 0.00100110592521327, 0.00100110592521327]
+[0.0, 0.8946688274680177, 0.06679115171318535, 0.029044862903021135, 0.0031650526385920007, 0.002373789478944001, 0.002373789478944001, 7.912631596480001E-4, 7.912631596480001E-4]
+[0.0, 0.8826810795843467, 0.07661100719615918, 0.02981674586041175, 0.003630389119694225, 0.002722791839770669, 0.002722791839770669, 9.07597279923556E-4, 9.07597279923556E-4]
+[1.0, 0.2704631172678178, 0.45449227323888225, 0.21043311837192044, 0.02153716370712658, 0.01615287278034494, 0.01615287278034494, 0.005384290926781644, 0.005384290926781644]
+[1.0, 0.2982370485653316, 0.4638127390267385, 0.17201370603775934, 0.021978835456723574, 0.016484126592542687, 0.016484126592542687, 0.005494708864180893, 0.005494708864180893]
+[0.0, 0.8873356626292286, 0.06961901079273779, 0.033148154805104836, 0.003299057257643013, 0.0024742929432322604, 0.0024742929432322604, 8.247643144107531E-4, 8.247643144107531E-4]
+[0.0, 0.8440823012582146, 0.0948969383759932, 0.047530030044610594, 0.004496910107060578, 0.003372682580295434, 0.003372682580295434, 0.0011242275267651443, 0.0011242275267651443]
+[0.0, 0.8073370324926793, 0.11321195284958782, 0.0633565868377677, 0.0053648092733218165, 0.004023606954991364, 0.004023606954991364, 0.001341202318330454, 0.001341202318330454]
+[0.0, 0.5195170521400464, 0.2562086760604949, 0.18785115621922485, 0.012141038526744686, 0.009105778895058517, 0.009105778895058517, 0.003035259631686171, 0.003035259631686171]
+[0.0, 0.4466020948766264, 0.29856835202705606, 0.21238450493599018, 0.014148349386775855, 0.010611262040081894, 0.010611262040081894, 0.0035370873466939634, 0.0035370873466939634]
+[0.0, 0.6618391052415187, 0.19752988526575024, 0.1125497830791259, 0.009360408804535073, 0.007020306603401307, 0.007020306603401307, 0.002340102201133768, 0.002340102201133768]
+[0.0, 0.5761517066235197, 0.2475824557435477, 0.14106904203707935, 0.011732265198617753, 0.008799198898963316, 0.008799198898963316, 0.0029330662996544378, 0.0029330662996544378]
+[0.0, 0.9089361795154469, 0.05885037342652028, 0.02384716537619006, 0.0027887605606142256, 0.00209157042046067, 0.00209157042046067, 6.971901401535563E-4, 6.971901401535563E-4]
+[0.0, 0.8156771462925994, 0.11283472765637823, 0.05544732528625029, 0.005346933588257448, 0.004010200191193087, 0.004010200191193087, 0.0013367333970643617, 0.0013367333970643617]
+[0.0, 0.7160585600562807, 0.16586896052560532, 0.09449223064085975, 0.0078600829257514, 0.005895062194313552, 0.005895062194313552, 0.0019650207314378496, 0.0019650207314378496]
+[0.0, 0.8147420682314094, 0.12166272202949356, 0.04629940440407508, 0.0057652684450074645, 0.004323951333755599, 0.004323951333755599, 0.001441317111251866, 0.001441317111251866]
+[0.0, 0.7802652975002501, 0.13259835593694377, 0.06828591058888935, 0.006283478657972225, 0.00471260899347917, 0.00471260899347917, 0.001570869664493056, 0.001570869664493056]
+[0.0, 0.7162468760273857, 0.17176578915021964, 0.08756878160575272, 0.008139517738880636, 0.006104638304160479, 0.006104638304160479, 0.0020348794347201586, 0.0020348794347201586]
+[0.0, 0.7050969113377036, 0.1669986043345781, 0.10416364322528857, 0.007913613700809927, 0.005935210275607446, 0.005935210275607446, 0.0019784034252024814, 0.0019784034252024814]
+[0.0, 0.6567121883079696, 0.19851551708779014, 0.11655094888505257, 0.00940711523972912, 0.007055336429796842, 0.007055336429796842, 0.0023517788099322798, 0.0023517788099322798]
+[0.0, 0.5456089408094382, 0.28317223445722645, 0.1309625181033705, 0.01341876887665505, 0.01006407665749129, 0.01006407665749129, 0.003354692219163762, 0.003354692219163762]
+[0.0, 0.7554684403981511, 0.14973397475979688, 0.07351111651154073, 0.007095489443503737, 0.005321617082627804, 0.005321617082627804, 0.001773872360875934, 0.001773872360875934]
+[0.0, 0.899061778008834, 0.06453568591830353, 0.027228019489758552, 0.0030581721943678973, 0.0022936291457759236, 0.0022936291457759236, 7.645430485919741E-4, 7.645430485919741E-4]
+[0.0, 0.7890631749193008, 0.12912189057106943, 0.06345871950347629, 0.006118738335384524, 0.004589053751538394, 0.004589053751538394, 0.0015296845838461309, 0.0015296845838461309]
+[0.0, 0.8831493163406035, 0.07153379154858361, 0.03514751144217671, 0.003389793556212015, 0.002542345167159012, 0.002542345167159012, 8.474483890530038E-4, 8.474483890530038E-4]
+[0.0, 0.5881197760591331, 0.23320956865232176, 0.14551713682051934, 0.011051172822675249, 0.00828837961700644, 0.00828837961700644, 0.0027627932056688118, 0.0027627932056688118]
+[0.0, 0.49200786149773795, 0.2866023826503033, 0.18064581279213188, 0.013581314353275666, 0.010185985764956752, 0.010185985764956752, 0.003395328588318916, 0.003395328588318916]
+[0.0, 0.6321880374055344, 0.2196522932092083, 0.11693347913269356, 0.01040873008418787, 0.007806547563140904, 0.007806547563140904, 0.002602182521046967, 0.002602182521046967]
+[0.0, 0.8458313965801445, 0.09437243987494388, 0.046379996934136025, 0.004472055536925118, 0.003354041652693839, 0.003354041652693839, 0.0011180138842312793, 0.0011180138842312793]
+[0.0, 0.9053173910081832, 0.0608642779018475, 0.025165748894809357, 0.0028841940650532337, 0.0021631455487899237, 0.0021631455487899237, 7.210485162633084E-4, 7.210485162633084E-4]
+[0.0, 0.6466129532166903, 0.20850351072137197, 0.11524227805826276, 0.00988041933455831, 0.007410314500918734, 0.007410314500918734, 0.002470104833639577, 0.002470104833639577]
+[0.0, 0.7154266687991191, 0.1667940528081456, 0.09406751672666147, 0.007903920555357916, 0.005927940416518438, 0.005927940416518438, 0.0019759801388394786, 0.0019759801388394786]
+[0.0, 0.8724639701188575, 0.08556160908096577, 0.029810818752403052, 0.0040545340159245605, 0.003040900511943421, 0.003040900511943421, 0.00101363350398114, 0.00101363350398114]
+[0.0, 0.6400584802967492, 0.20904328189568067, 0.12118024490103763, 0.009905997635510776, 0.0074294982266330835, 0.0074294982266330835, 0.0024764994088776935, 0.0024764994088776935]
+[0.0, 0.86518585889618, 0.08252769981563114, 0.040554145586204814, 0.003910765233994715, 0.002933073925496037, 0.002933073925496037, 9.776913084986786E-4, 9.776913084986786E-4]
+[0.0, 0.8529562442016175, 0.09508508770785638, 0.038441190100349514, 0.0045058259967254285, 0.0033793694975440716, 0.0033793694975440716, 0.001126456499181357, 0.001126456499181357]
+[0.0, 0.7960551138753181, 0.1271282527098705, 0.05874383778133551, 0.006024265211158715, 0.004518198908369037, 0.004518198908369037, 0.0015060663027896784, 0.0015060663027896784]
+[0.0, 0.8220898681482326, 0.11320472309508871, 0.048612008732445575, 0.005364466674744508, 0.004023350006058381, 0.004023350006058381, 0.0013411166686861267, 0.0013411166686861267]
+[0.0, 0.7392051817070322, 0.15387544221729993, 0.08504414880773173, 0.0072917424226453635, 0.0054688068169840235, 0.0054688068169840235, 0.0018229356056613404, 0.0018229356056613404]
+[0.0, 0.6578993743644921, 0.2011828502986255, 0.11231723642516506, 0.009533512970572441, 0.007150134727929332, 0.007150134727929332, 0.00238337824264311, 0.00238337824264311]
+[0.0, 0.9123560488011625, 0.05693799641635462, 0.02261154027526224, 0.0026981381690735122, 0.002023603626805134, 0.002023603626805134, 6.745345422683778E-4, 6.745345422683778E-4]
+[0.0, 0.8542094043822658, 0.08846191189519471, 0.044752769077688166, 0.004191971548283787, 0.0031439786612128414, 0.0031439786612128414, 0.0010479928870709468, 0.0010479928870709468]
+[0.0, 0.6892359523658749, 0.19199388236744486, 0.09147594761686056, 0.009098072549939908, 0.006823554412454933, 0.006823554412454933, 0.0022745181374849766, 0.0022745181374849766]
+[0.0, 0.7256943178990491, 0.15753512524338836, 0.09437506204874596, 0.007465164936272193, 0.005598873702204146, 0.005598873702204146, 0.001866291234068048, 0.001866291234068048]
+[0.0, 0.6257342252725469, 0.2119407165449715, 0.13219516042268678, 0.010043299253264965, 0.007532474439948726, 0.007532474439948726, 0.002510824813316241, 0.002510824813316241]
+[0.0, 0.7195205011837055, 0.1610795251006511, 0.09650060024179223, 0.007633124491283728, 0.005724843368462798, 0.005724843368462798, 0.0019082811228209318, 0.0019082811228209318]
+[0.0, 0.5610609564091465, 0.2395816100610973, 0.16529805346374507, 0.011353126688670364, 0.008514845016502775, 0.008514845016502775, 0.0028382816721675905, 0.0028382816721675905]
+[0.0, 0.7861440854784792, 0.13184016941449886, 0.063273094379737, 0.006247550242428293, 0.004685662681821221, 0.004685662681821221, 0.001561887560607073, 0.001561887560607073]
+[0.0, 0.7135065664277223, 0.16092459118722444, 0.10269149461276236, 0.007625782590763667, 0.005719336943072752, 0.005719336943072752, 0.0019064456476909166, 0.0019064456476909166]
+[0.0, 0.7232008644541068, 0.17115225224082045, 0.081315551669321, 0.008110443878583897, 0.006082832908937924, 0.006082832908937924, 0.0020276109696459738, 0.0020276109696459738]
+[0.0, 0.7467189965036395, 0.15473370706818457, 0.07655005658696212, 0.007332413280404609, 0.005499309960303457, 0.005499309960303457, 0.0018331033201011517, 0.0018331033201011517]
+[1.0, 0.33391947994302007, 0.3770728408720199, 0.23540228269165056, 0.017868465497769912, 0.013401349123327438, 0.013401349123327438, 0.004467116374442477, 0.004467116374442477]
+[0.0, 0.6615851907279504, 0.2054779494570846, 0.10372572138927902, 0.009737046141895366, 0.007302784606421526, 0.007302784606421526, 0.002434261535473841, 0.002434261535473841]
+[0.0, 0.7468751951044775, 0.15370599926539522, 0.07756766669642065, 0.007283712977902146, 0.00546278473342661, 0.00546278473342661, 0.001820928244475536, 0.001820928244475536]
+[0.0, 0.7962371348460977, 0.12411046654423605, 0.06200861723127908, 0.005881260459462508, 0.004410945344596882, 0.004410945344596882, 0.0014703151148656268, 0.0014703151148656268]
+[0.0, 0.8859092894917192, 0.07173761340015787, 0.03215474073510494, 0.0033994521243393937, 0.0025495890932545453, 0.0025495890932545453, 8.498630310848482E-4, 8.498630310848482E-4]
+[0.0, 0.7283371959209702, 0.16276847644050435, 0.08575484961081305, 0.007713159342570784, 0.0057848695069280896, 0.0057848695069280896, 0.0019282898356426958, 0.0019282898356426958]
+[0.0, 0.6091095454260056, 0.24502042752872466, 0.11103745428223843, 0.011610857587677095, 0.008708143190757823, 0.008708143190757823, 0.0029027143969192733, 0.0029027143969192733]
+[0.0, 0.727607820883395, 0.16842811829492613, 0.08001999727962696, 0.007981354514017231, 0.005986015885512925, 0.005986015885512925, 0.0019953386285043073, 0.0019953386285043073]
+[0.0, 0.8325816644368806, 0.10436491780577158, 0.048216701365808405, 0.004945572130512995, 0.0037091790978847437, 0.0037091790978847437, 0.0012363930326282485, 0.0012363930326282485]
+[0.0, 0.6584556595961978, 0.20902389228109033, 0.1028052116808869, 0.009905078813941655, 0.007428809110456243, 0.007428809110456243, 0.0024762697034854133, 0.0024762697034854133]
+[0.0, 0.8119789429994785, 0.11509799189909481, 0.05656051436171778, 0.005454183579903076, 0.004090637684927308, 0.004090637684927308, 0.001363545894975769, 0.001363545894975769]
+[0.0, 0.7261233520059156, 0.16763682674921943, 0.0824082492228902, 0.00794385734065826, 0.005957893005493697, 0.005957893005493697, 0.001985964335164565, 0.001985964335164565]
+[0.0, 0.8809164968800195, 0.07423455552283151, 0.034295621154694936, 0.003517775480818055, 0.0026383316106135418, 0.0026383316106135418, 8.794438702045137E-4, 8.794438702045137E-4]
+[0.0, 0.8646433004421937, 0.08288957231165892, 0.040683387057774974, 0.00392791339612411, 0.0029459350470930827, 0.0029459350470930827, 9.819783490310273E-4, 9.819783490310273E-4]
+[1.0, 0.08280937726768059, 0.4326000986446775, 0.42309126639179695, 0.02049975256528179, 0.015374814423961346, 0.015374814423961346, 0.0051249381413204466, 0.0051249381413204466]
+[1.0, 0.09062647354020073, 0.43688184174529465, 0.41038372622742697, 0.020702652829025947, 0.015526989621769462, 0.015526989621769462, 0.005175663207256486, 0.005175663207256486]
+[1.0, 0.08094855411161062, 0.4314601963666728, 0.4262540425146316, 0.020445735669028395, 0.0153343017517713, 0.0153343017517713, 0.005111433917257098, 0.005111433917257098]
+[2.0, 0.1030031088955938, 0.41321638084291595, 0.42503687897425857, 0.019581210429077286, 0.014685907821807969, 0.014685907821807969, 0.0048953026072693214, 0.0048953026072693214]
+[0.0, 0.6079146404610439, 0.24941207086002823, 0.10721639149760301, 0.011818965727108284, 0.008864224295331216, 0.008864224295331216, 0.0029547414317770706, 0.0029547414317770706]
+[0.0, 0.49562479145339305, 0.3172697716744049, 0.1420017591143, 0.015034559252634071, 0.011275919439475555, 0.011275919439475555, 0.0037586398131585173, 0.0037586398131585173]
+[0.0, 0.7875386058885679, 0.1301016883073115, 0.06386420087718406, 0.006165168308978873, 0.004623876231734156, 0.004623876231734156, 0.001541292077244718, 0.001541292077244718]
+[0.0, 0.86518585889618, 0.08252769981563114, 0.040554145586204814, 0.003910765233994715, 0.002933073925496037, 0.002933073925496037, 9.776913084986786E-4, 9.776913084986786E-4]
+[0.0, 0.539271627497915, 0.26295282119771407, 0.1603936751481882, 0.012460625385394244, 0.009345469039045685, 0.009345469039045685, 0.0031151563463485605, 0.0031151563463485605]
+[0.0, 0.8027430449458653, 0.11791421603159455, 0.06257982847201178, 0.005587636850176228, 0.004190727637632172, 0.004190727637632172, 0.0013969092125440568, 0.0013969092125440568]
+[0.0, 0.5197445130564702, 0.27470519291009776, 0.1664976782293814, 0.013017538601350225, 0.009763153951012671, 0.009763153951012671, 0.003254384650337556, 0.003254384650337556]
+[0.0, 0.7631918430305676, 0.14143936594894793, 0.07526150014819108, 0.006702430290764448, 0.005026822718073337, 0.005026822718073337, 0.0016756075726911117, 0.0016756075726911117]
+[0.0, 0.814453316198508, 0.11674272592511016, 0.05220758860074552, 0.005532123091878796, 0.004149092318909098, 0.004149092318909098, 0.0013830307729696988, 0.0013830307729696988]
+[0.0, 0.6980596862762458, 0.18333836930955427, 0.09253821106085773, 0.008687911117780684, 0.006515933338335515, 0.006515933338335515, 0.002171977779445171, 0.002171977779445171]
+[0.0, 0.8831493163406035, 0.07153379154858361, 0.03514751144217671, 0.003389793556212015, 0.002542345167159012, 0.002542345167159012, 8.474483890530038E-4, 8.474483890530038E-4]
+[0.0, 0.7515794233148988, 0.1456107556521357, 0.08210951741955202, 0.006900101204471173, 0.005175075903353381, 0.005175075903353381, 0.001725025301117793, 0.001725025301117793]
+[0.0, 0.6672243646079186, 0.19375021288682306, 0.11148152154850301, 0.00918130031891848, 0.006885975239188861, 0.006885975239188861, 0.0022953250797296196, 0.0022953250797296196]
+[0.0, 0.8982761056130216, 0.06538957137477382, 0.027038416438912038, 0.0030986355244308683, 0.002323976643323153, 0.002323976643323153, 7.746588811077169E-4, 7.746588811077169E-4]
+[0.0, 0.616171506775792, 0.23851742245357221, 0.11140297765096821, 0.011302697706555818, 0.008477023279916866, 0.008477023279916866, 0.002825674426638954, 0.002825674426638954]
+[0.0, 0.7519936499663236, 0.14812564691913302, 0.07882287774699565, 0.007019275122515928, 0.005264456341886947, 0.005264456341886947, 0.0017548187806289818, 0.0017548187806289818]
+[0.0, 0.8374515926131195, 0.10392289887278619, 0.04385163037976159, 0.004924626044777555, 0.003693469533583166, 0.003693469533583166, 0.0012311565111943884, 0.0012311565111943884]
+[0.0, 0.8019224563012864, 0.11905722520789348, 0.06209491556892581, 0.0056418009739648825, 0.0042313507304736625, 0.0042313507304736625, 0.0014104502434912204, 0.0014104502434912204]
+[0.0, 0.7621927618473888, 0.1448402262200454, 0.07237624825743431, 0.006863587891710484, 0.005147690918782865, 0.005147690918782865, 0.0017158969729276208, 0.0017158969729276208]
+[0.0, 0.587450085537492, 0.23599422976379236, 0.143006293479328, 0.011183130406462573, 0.008387347804846932, 0.008387347804846932, 0.002795782601615643, 0.002795782601615643]
+[0.0, 0.9395102390978827, 0.041240575420150034, 0.013386346376671548, 0.0019542797017652025, 0.0014657097763239025, 0.0014657097763239025, 4.885699254413006E-4, 4.885699254413006E-4]
+[0.0, 0.9149849602390704, 0.05551602335805614, 0.021606752306211664, 0.0026307546988872076, 0.001973066024165406, 0.001973066024165406, 6.576886747218018E-4, 6.576886747218018E-4]
+[0.0, 0.7721338510355218, 0.13478644143014018, 0.07391820914035209, 0.006387166131328655, 0.004790374598496493, 0.004790374598496493, 0.0015967915328321636, 0.0015967915328321636]
+[0.0, 0.7797656716242672, 0.13806181689368735, 0.06254537944554663, 0.006542377345499602, 0.004906783009124703, 0.004906783009124703, 0.0016355943363749004, 0.0016355943363749004]
+[0.0, 0.7949213902027028, 0.13559552966995853, 0.05020656020119136, 0.006425506642049108, 0.004819129981536833, 0.004819129981536833, 0.0016063766605122769, 0.0016063766605122769]
+[0.0, 0.8134641935577549, 0.11176726187198162, 0.05887949678373099, 0.005296349262177558, 0.003972261946633169, 0.003972261946633169, 0.0013240873155443893, 0.0013240873155443893]
+[0.0, 0.8341050676211905, 0.10606193715960972, 0.044755027309495314, 0.005025989303234792, 0.0037694919774260943, 0.0037694919774260943, 0.0012564973258086978, 0.0012564973258086978]
+[0.0, 0.8704255079453599, 0.08306441091569777, 0.03470148556011, 0.003936198526277535, 0.0029521488947081517, 0.0029521488947081517, 9.840496315693835E-4, 9.840496315693835E-4]
+[0.0, 0.6920909956778286, 0.17311697656164507, 0.11018138715631565, 0.008203546868070215, 0.006152660151052663, 0.006152660151052663, 0.0020508867170175534, 0.0020508867170175534]
+[0.0, 0.6095468624982732, 0.21952611227498298, 0.13971877309720543, 0.010402750709846118, 0.00780206303238459, 0.00780206303238459, 0.002600687677461529, 0.002600687677461529]
+[0.0, 0.771676318061064, 0.1386387741701576, 0.06997575438199258, 0.006569717795595278, 0.00492728834669646, 0.00492728834669646, 0.0016424294488988193, 0.0016424294488988193]
+[0.0, 0.7060891450656225, 0.17901406446148183, 0.0894478085702356, 0.008482993967553346, 0.006362245475665011, 0.006362245475665011, 0.002120748491888336, 0.002120748491888336]
+[0.0, 0.8533861627030744, 0.08974905439675185, 0.044105885614674524, 0.004252965761833082, 0.0031897243213748123, 0.0031897243213748123, 0.0010632414404582703, 0.0010632414404582703]
+[0.0, 0.7514961482299862, 0.14948337949176893, 0.077769629050488, 0.007083614409252248, 0.0053127108069391865, 0.0053127108069391865, 0.0017709036023130615, 0.0017709036023130615]
+[0.0, 0.6244643275974965, 0.218636096439892, 0.12581785018701308, 0.01036057525853275, 0.007770431443899564, 0.007770431443899564, 0.002590143814633187, 0.002590143814633187]
+[0.0, 0.9051233505447164, 0.0598277092275633, 0.02654371861851314, 0.0028350738697358437, 0.002126305402301883, 0.002126305402301883, 7.087684674339608E-4, 7.087684674339608E-4]
+[0.0, 0.8150596844921463, 0.11220972913026513, 0.056778636599067615, 0.005317316592840376, 0.003987987444630282, 0.003987987444630282, 0.0013293291482100937, 0.0013293291482100937]
+[0.0, 0.8626877143763725, 0.0840565668853511, 0.041306076368554843, 0.0039832141232406006, 0.0029874105924304504, 0.0029874105924304504, 9.9580353081015E-4, 9.9580353081015E-4]
+[0.0, 0.7329153158005351, 0.16053401230265615, 0.08372884956602335, 0.007607274110261794, 0.005705455582696347, 0.005705455582696347, 0.0019018185275654484, 0.0019018185275654484]
+[0.0, 0.7818070683415825, 0.13531131956256476, 0.06364549602233757, 0.006412038691171663, 0.004809029018378748, 0.004809029018378748, 0.0016030096727929156, 0.0016030096727929156]
+[0.0, 0.698998828831502, 0.18500661103880106, 0.0896936663403603, 0.008766964596445576, 0.006575223447334183, 0.006575223447334183, 0.002191741149111394, 0.002191741149111394]
+[0.0, 0.8848798751913446, 0.07299691041689617, 0.031745833945490624, 0.0034591268154229374, 0.0025943451115672035, 0.0025943451115672035, 8.647817038557342E-4, 8.647817038557342E-4]
+[0.0, 0.8459418150129013, 0.09430486622415653, 0.046346758551647826, 0.004468853403764693, 0.0033516400528235198, 0.0033516400528235198, 0.001117213350941173, 0.001117213350941173]
+[0.0, 0.9079543130771096, 0.0604122897997576, 0.023045070421332553, 0.0028627755672666552, 0.002147081675449992, 0.002147081675449992, 7.156938918166637E-4, 7.156938918166637E-4]
+[0.0, 0.7266830527681217, 0.1600693500619492, 0.09049183211229792, 0.007585255019210347, 0.005688941264407762, 0.005688941264407762, 0.0018963137548025865, 0.0018963137548025865]
+[0.0, 0.8355274677531491, 0.10486645979147417, 0.04469805589557443, 0.004969338853267371, 0.0037270041399505285, 0.0037270041399505285, 0.0012423347133168425, 0.0012423347133168425]
+[0.0, 0.714056493224402, 0.1752260094994182, 0.08580703251442627, 0.008303488253917864, 0.0062276161904383995, 0.0062276161904383995, 0.002075872063479466, 0.002075872063479466]
+[0.0, 0.7739347225937508, 0.13469702723703464, 0.07221946306799235, 0.006382929033740767, 0.004787196775305576, 0.004787196775305576, 0.0015957322584351915, 0.0015957322584351915]
+[0.0, 0.6687272292305135, 0.19287552953733883, 0.11097768693384336, 0.009139851432768025, 0.00685488857457602, 0.00685488857457602, 0.002284962858192006, 0.002284962858192006]
+[0.0, 0.878375171356708, 0.07559805196759023, 0.03527961296994978, 0.0035823879019172772, 0.0026867909264379586, 0.0026867909264379586, 8.955969754793193E-4, 8.955969754793193E-4]
+[0.0, 0.7115971452181001, 0.16959949945903657, 0.09469276599337566, 0.008036863109829226, 0.00602764733237192, 0.00602764733237192, 0.002009215777457306, 0.002009215777457306]
+[0.0, 0.8621791935077453, 0.08436778117535984, 0.04145914012827441, 0.003997961729540153, 0.0029984712971551147, 0.0029984712971551147, 9.99490432385038E-4, 9.99490432385038E-4]
+[0.0, 0.6149920144147513, 0.2241486402155188, 0.1289939458241092, 0.010621799848540187, 0.007966349886405143, 0.007966349886405143, 0.002655449962135047, 0.002655449962135047]
+[0.0, 0.7945095351066785, 0.12883125637912188, 0.058344310620829454, 0.0061049659644567275, 0.004578724473342547, 0.004578724473342547, 0.0015262414911141817, 0.0015262414911141817]
+[0.0, 0.8745959165654417, 0.08125619389715671, 0.03259635354949771, 0.003850511995968004, 0.0028878839969760034, 0.0028878839969760034, 9.626279989920007E-4, 9.626279989920007E-4]
+[0.0, 0.9213528578635178, 0.050827609283374764, 0.02059378267141499, 0.0024085833938975276, 0.0018064375454231443, 0.0018064375454231443, 6.021458484743818E-4, 6.021458484743818E-4]
+[0.0, 0.9031245678615741, 0.06210651004583712, 0.025939741799137668, 0.0029430600978170005, 0.0022072950733627505, 0.0022072950733627505, 7.3576502445425E-4, 7.3576502445425E-4]
+[0.0, 0.9107993880299642, 0.057798160548514506, 0.023185754335563163, 0.002738899028652722, 0.002054174271489542, 0.002054174271489542, 6.847247571631804E-4, 6.847247571631804E-4]
+[0.0, 0.6857292630903667, 0.1938562986394567, 0.09285545595985803, 0.009186327436772833, 0.006889745577579626, 0.006889745577579626, 0.0022965818591932077, 0.0022965818591932077]
+[0.0, 0.9228496805960326, 0.05101786379429188, 0.01887965848270648, 0.0024175990423230555, 0.001813199281742292, 0.001813199281742292, 6.043997605807638E-4, 6.043997605807638E-4]
+[0.0, 0.7699782775157811, 0.13661202437345457, 0.07398867135275863, 0.006473675586001902, 0.004855256689501428, 0.004855256689501428, 0.0016184188965004754, 0.0016184188965004754]
+[0.0, 0.6417237666610073, 0.2049595940733895, 0.12417919123300708, 0.009712482677532035, 0.007284362008149029, 0.007284362008149029, 0.002428120669383009, 0.002428120669383009]
+[0.0, 0.7733368578542439, 0.13505314624435572, 0.0724105822407524, 0.006399804553549356, 0.004799853415162018, 0.004799853415162018, 0.0015999511383873388, 0.0015999511383873388]
+[0.0, 0.7175981688971237, 0.1698815865601042, 0.08836955317129314, 0.008050230457159612, 0.006037672842869711, 0.006037672842869711, 0.002012557614289903, 0.002012557614289903]
+[0.0, 0.86518585889618, 0.08252769981563114, 0.040554145586204814, 0.003910765233994715, 0.002933073925496037, 0.002933073925496037, 9.776913084986786E-4, 9.776913084986786E-4]
+[0.0, 0.6378926865653646, 0.2276319917359666, 0.10211472223637603, 0.010786866487430925, 0.008090149865573196, 0.008090149865573196, 0.0026967166218577307, 0.0026967166218577307]
+[0.0, 0.8739831150626387, 0.08143894380200734, 0.033000425071330206, 0.0038591720213413286, 0.0028943790160059968, 0.0028943790160059968, 9.647930053353319E-4, 9.647930053353319E-4]
+[0.0, 0.7320903328379339, 0.16404464123160178, 0.08054412587442619, 0.007773633352012723, 0.005830225014009543, 0.005830225014009543, 0.0019434083380031806, 0.0019434083380031806]
+[1.0, 0.2659472417560864, 0.45597233208598376, 0.2132585270391226, 0.021607299706269192, 0.016205474779701898, 0.016205474779701898, 0.005401824926567297, 0.005401824926567297]
+[0.0, 0.8643424126739524, 0.08304389071989136, 0.04080801821761969, 0.00393522612951216, 0.00295141959713412, 0.00295141959713412, 9.838065323780397E-4, 9.838065323780397E-4]
+[0.0, 0.8945163505729579, 0.06688781635115504, 0.029086933130233784, 0.003169633315217825, 0.0023772249864133692, 0.0023772249864133692, 7.924083288044561E-4, 7.924083288044561E-4]
+[0.0, 0.8871185337297366, 0.07408929426118865, 0.02825949618549716, 0.003510891941192592, 0.0026331689558944447, 0.0026331689558944447, 8.77722985298148E-4, 8.77722985298148E-4]
+[0.0, 0.7488165012912755, 0.14711088718451337, 0.08315904634202674, 0.006971188394061434, 0.005228391295546077, 0.005228391295546077, 0.0017427970985153581, 0.0017427970985153581]
+[0.0, 0.869788260643289, 0.08459094117538868, 0.03359518814013667, 0.00400853668039521, 0.003006402510296407, 0.003006402510296407, 0.0010021341700988022, 0.0010021341700988022]
+[0.0, 0.8602553109533075, 0.08531647344577246, 0.04229946250405146, 0.0040429176989562115, 0.003032188274217159, 0.003032188274217159, 0.0010107294247390529, 0.0010107294247390529]
+[0.0, 0.7254473860561648, 0.1634497995999503, 0.0878664781122836, 0.007745445410533774, 0.005809084057900331, 0.005809084057900331, 0.001936361352633443, 0.001936361352633443]
+[0.0, 0.8513289103232767, 0.09104082442072335, 0.0446877274724129, 0.004314179261195724, 0.0032356344458967937, 0.0032356344458967937, 0.001078544815298931, 0.001078544815298931]
+[0.0, 0.8018042830151947, 0.13104565085985506, 0.04852036567550672, 0.006209900149814465, 0.0046574251123608496, 0.0046574251123608496, 0.001552475037453616, 0.001552475037453616]
+[0.0, 0.5024241405463065, 0.29036566854303797, 0.1659312519282075, 0.01375964632748273, 0.01031973474561205, 0.01031973474561205, 0.003439911581870682, 0.003439911581870682]
+[0.0, 0.8659000045861684, 0.08212018881033327, 0.040305443445698245, 0.0038914543859334054, 0.0029185907894500544, 0.0029185907894500544, 9.728635964833511E-4, 9.728635964833511E-4]
+[0.0, 0.6904371905067309, 0.18128916171663084, 0.10250123369535442, 0.008590804693761278, 0.00644310352032096, 0.00644310352032096, 0.0021477011734403195, 0.0021477011734403195]
+[0.0, 0.862906480215033, 0.08392268229398175, 0.0412402284109273, 0.003976869693352639, 0.00298265227001448, 0.00298265227001448, 9.942174233381598E-4, 9.942174233381598E-4]
+[0.0, 0.6641239722145645, 0.18471814147614324, 0.12489800190489761, 0.008753294801464882, 0.0065649711010986635, 0.0065649711010986635, 0.0021883237003662206, 0.0021883237003662206]
+[0.0, 0.5728209540647012, 0.23404882313832778, 0.15985739430551021, 0.011090942830486915, 0.008318207122865188, 0.008318207122865188, 0.0027727357076217283, 0.0027727357076217283]
+[0.0, 0.771496086919436, 0.137351197798971, 0.07162660621519155, 0.006508703022133775, 0.004881527266600333, 0.004881527266600333, 0.0016271757555334436, 0.0016271757555334436]
+[0.0, 0.8731507769669881, 0.0813177529394004, 0.0339711827544843, 0.003853429113042422, 0.002890071834781817, 0.002890071834781817, 9.633572782606053E-4, 9.633572782606053E-4]
+[0.0, 0.9050648432830605, 0.06215086337929273, 0.023948807689452994, 0.002945161882731368, 0.0022088714120485266, 0.0022088714120485266, 7.36290470682842E-4, 7.36290470682842E-4]
+[0.0, 0.8809811019651662, 0.07419429152172133, 0.03427700407809123, 0.003515867478340401, 0.002636900608755301, 0.002636900608755301, 8.789668695851E-4, 8.789668695851E-4]
+[0.0, 0.671779242306372, 0.18651839180180488, 0.11518655445680188, 0.00883860381167374, 0.006628952858755308, 0.006628952858755308, 0.002209650952918435, 0.002209650952918435]
+[0.0, 0.597761299547581, 0.23009832600356214, 0.1394291561883666, 0.010903739420163452, 0.008177804565122591, 0.008177804565122591, 0.0027259348550408625, 0.0027259348550408625]
+[0.0, 0.9345365766099157, 0.04402410053361309, 0.015180772495464068, 0.0020861834536691267, 0.0015646375902518452, 0.0015646375902518452, 5.215458634172816E-4, 5.215458634172816E-4]
+[0.0, 0.5705978000806451, 0.23988167912522587, 0.15541848233585404, 0.011367346152758336, 0.008525509614568754, 0.008525509614568754, 0.002841836538189584, 0.002841836538189584]
+[0.0, 0.6038094146817047, 0.22909499608395337, 0.13452700627484504, 0.010856194319832308, 0.008142145739874233, 0.008142145739874233, 0.0027140485799580765, 0.0027140485799580765]
+[0.0, 0.626033232690372, 0.2191870689441846, 0.1236196452844863, 0.010386684360319035, 0.007790013270239279, 0.007790013270239279, 0.002596671090079759, 0.002596671090079759]
+[0.0, 0.7137962316290734, 0.16379550801424445, 0.09912277755547776, 0.007761827600401435, 0.005821370700301077, 0.005821370700301077, 0.0019404569001003583, 0.0019404569001003583]
+[0.0, 0.9175130056846684, 0.05413983494772686, 0.020650536848349655, 0.0025655408397518434, 0.0019241556298138826, 0.0019241556298138826, 6.413852099379607E-4, 6.413852099379607E-4]
+[0.0, 0.8960598140491783, 0.06681392179864448, 0.027627869197487123, 0.003166131651563253, 0.00237459873867244, 0.00237459873867244, 7.91532912890813E-4, 7.91532912890813E-4]
+[0.0, 0.8811867023377787, 0.07428047879107472, 0.03397296388901622, 0.0035199516607101163, 0.0026399637455325874, 0.0026399637455325874, 8.79987915177529E-4, 8.79987915177529E-4]
+[0.0, 0.5574722604890615, 0.2541216474211492, 0.15227967249393407, 0.012042139865285096, 0.009031604898963824, 0.009031604898963824, 0.0030105349663212735, 0.0030105349663212735]
+[0.0, 0.5104211808648867, 0.2732394812863096, 0.17749509041346498, 0.012948082478446301, 0.009711061858834727, 0.009711061858834727, 0.003237020619611575, 0.003237020619611575]
+[0.0, 0.8772780927471229, 0.0811458731548339, 0.0300401815179392, 0.00384528419336805, 0.002883963145026038, 0.002883963145026038, 9.613210483420123E-4, 9.613210483420123E-4]
+[0.0, 0.7761370519787193, 0.13241920705085236, 0.0726187731449151, 0.0062749892751710525, 0.004706241956378291, 0.004706241956378291, 0.001568747318792763, 0.001568747318792763]
+[0.0, 0.9333614978417238, 0.04470926511344088, 0.015573282376267822, 0.0021186515561891443, 0.0015889886671418582, 0.0015889886671418582, 5.29662889047286E-4, 5.29662889047286E-4]
+[0.0, 0.768034127255418, 0.14584006893744655, 0.06539290057834811, 0.006910967742929053, 0.005183225807196791, 0.005183225807196791, 0.001727741935732263, 0.001727741935732263]
+[0.0, 0.8657655730790785, 0.08217291293446059, 0.04037965546630046, 0.0038939528400535424, 0.0029204646300401574, 0.0029204646300401574, 9.734882100133855E-4, 9.734882100133855E-4]
+[0.0, 0.7490186504564308, 0.1499019555398906, 0.07976904520407989, 0.007103449599866237, 0.005327587199899679, 0.005327587199899679, 0.001775862399966559, 0.001775862399966559]
+[0.0, 0.9198509441766545, 0.053898172681181356, 0.01858861579308117, 0.0025540891163609593, 0.0019155668372707196, 0.0019155668372707196, 6.385222790902397E-4, 6.385222790902397E-4]
+[0.0, 0.8605515500770652, 0.08500579362841981, 0.04235807003488933, 0.004028195419875116, 0.003021146564906337, 0.003021146564906337, 0.0010070488549687787, 0.0010070488549687787]
+[0.0, 0.8831493163406035, 0.07153379154858361, 0.03514751144217671, 0.003389793556212015, 0.002542345167159012, 0.002542345167159012, 8.474483890530038E-4, 8.474483890530038E-4]
+[0.0, 0.9007546070130672, 0.06353967333117158, 0.026672798127666392, 0.0030109738426983535, 0.002258230382023765, 0.002258230382023765, 7.527434606745883E-4, 7.527434606745883E-4]
+[0.0, 0.7836392106410494, 0.1296320116606491, 0.0683000429020636, 0.006142911598745946, 0.00460718369905946, 0.00460718369905946, 0.0015357278996864863, 0.0015357278996864863]
+[0.0, 0.6975759370729233, 0.172470509651011, 0.10543481564472405, 0.008172912543780508, 0.006129684407835382, 0.006129684407835382, 0.0020432281359451265, 0.0020432281359451265]
+[0.0, 0.5757788085845664, 0.23591387127391755, 0.15476935283879492, 0.011179322434240389, 0.008384491825680294, 0.008384491825680294, 0.0027948306085600967, 0.0027948306085600967]
+[0.0, 0.5778916158503572, 0.23124878376612037, 0.15798483084639228, 0.010958256512376653, 0.008218692384282491, 0.008218692384282491, 0.0027395641280941628, 0.0027395641280941628]
+[0.0, 0.4814442881563214, 0.28301292775105596, 0.19530912480880058, 0.013411219761274087, 0.010058414820955567, 0.010058414820955567, 0.0033528049403185214, 0.0033528049403185214]
+[0.0, 0.7474150593012225, 0.15466382759971667, 0.0759338074567813, 0.0073291018807598255, 0.00549682641056987, 0.00549682641056987, 0.0018322754701899562, 0.0018322754701899562]
+[0.0, 0.9122240136713203, 0.05717153272722451, 0.022476839125467503, 0.002709204825329117, 0.002031903618996838, 0.002031903618996838, 6.773012063322791E-4, 6.773012063322791E-4]
+[0.0, 0.8904217500306288, 0.07043731944781327, 0.029127426424593594, 0.003337834698988108, 0.0025033760242410812, 0.0025033760242410812, 8.344586747470268E-4, 8.344586747470268E-4]
+[0.0, 0.8510371069648134, 0.09801133463257185, 0.03701807955097637, 0.00464449295054611, 0.0034833697129095825, 0.0034833697129095825, 0.0011611232376365272, 0.0011611232376365272]
+[0.0, 0.9011110409854282, 0.06200432831583911, 0.02806997675551739, 0.0029382179810717333, 0.0022036634858038, 0.0022036634858038, 7.345544952679332E-4, 7.345544952679332E-4]
+[0.0, 0.8555311026287727, 0.0884363753852307, 0.043460237660259284, 0.00419076144191238, 0.003143071081434286, 0.003143071081434286, 0.0010476903604780948, 0.0010476903604780948]
+[0.0, 0.7318775983753293, 0.16012271199646558, 0.08523633853586841, 0.0075877836974455526, 0.005690837773084166, 0.005690837773084166, 0.0018969459243613877, 0.0018969459243613877]
+[0.0, 0.6504516510924562, 0.2139206420684865, 0.10521633907874539, 0.010137122586770676, 0.007602841940078009, 0.007602841940078009, 0.002534280646692669, 0.002534280646692669]
+[0.0, 0.6587657510138097, 0.216929445230154, 0.09346569878166623, 0.010279701658123324, 0.007709776243592494, 0.007709776243592494, 0.0025699254145308305, 0.0025699254145308305]
+[0.0, 0.8503562204461577, 0.09191309735747251, 0.04466414042321767, 0.004355513924384131, 0.0032666354432880993, 0.0032666354432880993, 0.0010888784810960327, 0.0010888784810960327]
+[0.0, 0.9008090830641401, 0.06341877585499063, 0.026756406569295465, 0.003005244837191324, 0.0022539336278934933, 0.0022539336278934933, 7.51311209297831E-4, 7.51311209297831E-4]
+[0.0, 0.8474311172676773, 0.09339344455543239, 0.04589844741380041, 0.004425663587696651, 0.003319247690772488, 0.003319247690772488, 0.0011064158969241625, 0.0011064158969241625]
+[0.0, 0.8262591818182362, 0.10735693531535088, 0.05112181554123231, 0.005087355775060299, 0.003815516831295225, 0.003815516831295225, 0.0012718389437650745, 0.0012718389437650745]
+[0.0, 0.8704255079453599, 0.08306441091569777, 0.03470148556011, 0.003936198526277535, 0.0029521488947081517, 0.0029521488947081517, 9.840496315693835E-4, 9.840496315693835E-4]
+[0.0, 0.8717492599603414, 0.07994781793022368, 0.036937387352241495, 0.0037885115857311143, 0.002841383689298336, 0.002841383689298336, 9.471278964327783E-4, 9.471278964327783E-4]
+[0.0, 0.7680371777022221, 0.14332192521723486, 0.06826597798086195, 0.0067916396998937275, 0.005093729774920297, 0.005093729774920297, 0.0016979099249734317, 0.0016979099249734317]
+[0.0, 0.8155201120184589, 0.11440948360987849, 0.05380573328763778, 0.0054215570280083825, 0.004066167771006288, 0.004066167771006288, 0.0013553892570020956, 0.0013553892570020956]
+[0.0, 0.7500237786564719, 0.15457154712598437, 0.07343048734396572, 0.007324728957859331, 0.0054935467183944995, 0.0054935467183944995, 0.0018311822394648325, 0.0018311822394648325]
+[0.0, 0.8733668454503578, 0.07824855850193095, 0.037260631261954065, 0.0037079882619192187, 0.0027809911964394142, 0.0027809911964394142, 9.269970654798045E-4, 9.269970654798045E-4]
+[1.0, 0.1787027137223603, 0.404864818969681, 0.3588761100352594, 0.019185452424233234, 0.01438908931817493, 0.01438908931817493, 0.004796363106058308, 0.004796363106058308]
+[1.0, 0.14585378636546661, 0.4303051056989682, 0.3626681108277794, 0.020390999035928687, 0.015293249276946518, 0.015293249276946518, 0.005097749758982171, 0.005097749758982171]
+[1.0, 0.15518564240769453, 0.4310589761666218, 0.3524752126498729, 0.02042672292527034, 0.01532004219395276, 0.01532004219395276, 0.005106680731317585, 0.005106680731317585]
+[0.0, 0.5923701944997259, 0.25714022217572063, 0.11393403736629765, 0.012185181986085323, 0.009138886489563994, 0.009138886489563994, 0.00304629549652133, 0.00304629549652133]
+[0.0, 0.42792989006601495, 0.34727311012737383, 0.17542799005032167, 0.01645633658542996, 0.012342252439072473, 0.012342252439072473, 0.004114084146357489, 0.004114084146357489]
+[0.0, 0.8623224524169842, 0.0842801068931726, 0.041416019444921626, 0.003993807081640608, 0.002995355311230456, 0.002995355311230456, 9.984517704101517E-4, 9.984517704101517E-4]
+[0.0, 0.7492907927012517, 0.15069432506820288, 0.07859188866280002, 0.007140997855915093, 0.005355748391936321, 0.005355748391936321, 0.001785249463978773, 0.001785249463978773]
+[0.0, 0.8655805492255121, 0.08228614815677562, 0.04043534636170024, 0.0038993187520041067, 0.0029244890640030803, 0.0029244890640030803, 9.748296880010267E-4, 9.748296880010267E-4]
+[0.0, 0.6608339485579197, 0.1974694792551691, 0.11362393320734208, 0.009357546326523051, 0.007018159744892291, 0.007018159744892291, 0.002339386581630763, 0.002339386581630763]
+[0.0, 0.8130388442670146, 0.11449054079759002, 0.05619442060648263, 0.005425398109637652, 0.00406904858222824, 0.00406904858222824, 0.0013563495274094128, 0.0013563495274094128]
+[0.0, 0.8758938342728573, 0.07691420723511881, 0.03625768763530466, 0.0036447569522396386, 0.0027335677141797294, 0.0027335677141797294, 9.111892380599094E-4, 9.111892380599094E-4]
+[0.0, 0.7202418599473319, 0.1763767624628171, 0.07830731958514128, 0.008358019334903165, 0.006268514501177375, 0.006268514501177375, 0.002089504833725791, 0.002089504833725791]
+[0.0, 0.8785478142861588, 0.07549076872936435, 0.035229504869130894, 0.003577304038448632, 0.002682978028836475, 0.002682978028836475, 8.94326009612158E-4, 8.94326009612158E-4]
+[0.0, 0.8009795356481961, 0.12159341500065818, 0.06014109683594445, 0.005761984171733807, 0.004321488128800357, 0.004321488128800357, 0.0014404960429334516, 0.0014404960429334516]
+[0.0, 0.6839750814539077, 0.18646681059364523, 0.10304962940066575, 0.008836159517260484, 0.006627119637945365, 0.006627119637945365, 0.002209039879315121, 0.002209039879315121]
+[0.0, 0.9168906815403277, 0.054685375640873425, 0.020649765190849732, 0.002591392542649819, 0.0019435444069873641, 0.0019435444069873641, 6.478481356624545E-4, 6.478481356624545E-4]
+[0.0, 0.8532571017288517, 0.08931426464833547, 0.04473154687981017, 0.004232362247667506, 0.0031742716857506305, 0.0031742716857506305, 0.0010580905619168763, 0.0010580905619168763]
+[0.0, 0.9209963498267387, 0.05198439648832922, 0.019629052420958793, 0.0024634004213243466, 0.00184755031599326, 0.00184755031599326, 6.158501053310866E-4, 6.158501053310866E-4]
+[0.0, 0.9191180986591742, 0.05322003755293574, 0.020096001426081023, 0.0025219541206029515, 0.001891465590452212, 0.001891465590452212, 6.304885301507378E-4, 6.304885301507378E-4]
+[0.0, 0.6809459789602301, 0.17873340902288062, 0.11491152862834511, 0.008469694462848076, 0.006352270847136058, 0.006352270847136058, 0.0021174236157120185, 0.0021174236157120185]
+[0.0, 0.8655805492255121, 0.08228614815677562, 0.04043534636170024, 0.0038993187520041067, 0.0029244890640030803, 0.0029244890640030803, 9.748296880010267E-4, 9.748296880010267E-4]
+[0.0, 0.5623889316991408, 0.23976166368749496, 0.1637644277793366, 0.011361658944675846, 0.008521244208506886, 0.008521244208506886, 0.002840414736168961, 0.002840414736168961]
+[0.0, 0.6504350142459584, 0.19581848209868435, 0.1259085735903256, 0.009279310021677175, 0.006959482516257883, 0.006959482516257883, 0.0023198275054192937, 0.0023198275054192937]
+[0.0, 0.5579171164797925, 0.24674401369706167, 0.16026126875277094, 0.01169253369012494, 0.008769400267593708, 0.008769400267593708, 0.0029231334225312345, 0.0029231334225312345]
+[0.0, 0.653746430118019, 0.1958778402104445, 0.12252936114377012, 0.009282122842588768, 0.006961592131941577, 0.006961592131941577, 0.0023205307106471916, 0.0023205307106471916]
+[0.0, 0.6883221497993132, 0.18747110426940536, 0.0975554950690881, 0.008883750287397758, 0.006662812715548319, 0.006662812715548319, 0.002220937571849439, 0.002220937571849439]
+[0.0, 0.577196842486977, 0.2502602609481047, 0.136965419057872, 0.011859159169015412, 0.00889436937676156, 0.00889436937676156, 0.0029647897922538526, 0.0029647897922538526]
+[0.0, 0.7302003517034646, 0.16828371411131665, 0.07759239941819036, 0.007974511589009447, 0.005980883691757086, 0.005980883691757086, 0.0019936278972523614, 0.0019936278972523614]
+[0.0, 0.49993282820645574, 0.2860316617980582, 0.17337270170394656, 0.013554269430513221, 0.010165702072884919, 0.010165702072884919, 0.003388567357628305, 0.003388567357628305]
+[0.0, 0.8680311583131942, 0.08130262353143272, 0.03910808164182916, 0.003852712171181409, 0.002889534128386057, 0.002889534128386057, 9.631780427953522E-4, 9.631780427953522E-4]
+[0.0, 0.9302926468767176, 0.04654654096499197, 0.01654366683949707, 0.0022057151062645232, 0.0016542863296983925, 0.0016542863296983925, 5.514287765661307E-4, 5.514287765661307E-4]
+[0.0, 0.8157219360325794, 0.11394801942627428, 0.05413097608835937, 0.005399689484262407, 0.004049767113196806, 0.004049767113196806, 0.0013499223710656016, 0.0013499223710656016]
+[0.0, 0.7043829190248851, 0.1767038787887764, 0.09379264069887497, 0.008373520495821156, 0.006280140371865868, 0.006280140371865868, 0.0020933801239552885, 0.0020933801239552885]
+[0.0, 0.7183664511281951, 0.17310609960627407, 0.08391835495010608, 0.00820303143847492, 0.006152273578856192, 0.006152273578856192, 0.0020507578596187298, 0.0020507578596187298]
+[0.0, 0.8643424126739524, 0.08304389071989136, 0.04080801821761969, 0.00393522612951216, 0.00295141959713412, 0.00295141959713412, 9.838065323780397E-4, 9.838065323780397E-4]
+[0.0, 0.8696023268649246, 0.08706702978605141, 0.030953027813567912, 0.004125871845152047, 0.0030944038838640357, 0.0030944038838640357, 0.0010314679612880115, 0.0010314679612880115]
+[0.0, 0.6815540435569507, 0.20424355174137693, 0.08516675061696377, 0.009678551361569527, 0.007258913521177146, 0.007258913521177146, 0.002419637840392381, 0.002419637840392381]
+[0.0, 0.5756915021151617, 0.2691774549966617, 0.11686426088184956, 0.012755594002109065, 0.0095666955015818, 0.0095666955015818, 0.003188898500527266, 0.003188898500527266]
+[0.0, 0.9264336329189283, 0.04900516183343118, 0.017594537682231293, 0.002322222521803138, 0.0017416668913523554, 0.0017416668913523554, 5.805556304507844E-4, 5.805556304507844E-4]
+[0.0, 0.8714572216154535, 0.08285137281768602, 0.033913095891636755, 0.003926103225074644, 0.0029445774188059833, 0.0029445774188059833, 9.815258062686608E-4, 9.815258062686608E-4]
+[0.0, 0.7091323296471989, 0.17147633007537796, 0.09501393711666853, 0.008125801053584862, 0.006094350790188648, 0.006094350790188648, 0.002031450263396215, 0.002031450263396215]
+[0.0, 0.7845458871933332, 0.13242865310070295, 0.0641991490119312, 0.006275436898010861, 0.004706577673508147, 0.004706577673508147, 0.001568859224502715, 0.001568859224502715]
+[0.0, 0.651535562954947, 0.20560016364258507, 0.1136357607743448, 0.009742837542707746, 0.0073071281570308115, 0.0073071281570308115, 0.002435709385676936, 0.002435709385676936]
+[0.0, 0.7974020267475783, 0.12302227139868081, 0.062086620379236124, 0.005829693824835025, 0.004372270368626269, 0.004372270368626269, 0.0014574234562087561, 0.0014574234562087561]
+[0.0, 0.641528996736211, 0.20507097215441017, 0.1242467493556907, 0.009717760584562739, 0.007288320438422056, 0.007288320438422056, 0.0024294401461406843, 0.0024294401461406843]
+[0.0, 0.7370278839332933, 0.16016248518528653, 0.0800406255564647, 0.007589668441651845, 0.005692251331238885, 0.005692251331238885, 0.001897417110412961, 0.001897417110412961]
+[0.0, 0.7388269486295495, 0.1534550458890147, 0.08590254255985239, 0.0072718209738611385, 0.005453865730395855, 0.005453865730395855, 0.0018179552434652844, 0.0018179552434652844]
+[0.0, 0.6066834977966491, 0.2320529766962823, 0.12827443036436387, 0.010996365047568202, 0.008247273785676154, 0.008247273785676154, 0.00274909126189205, 0.00274909126189205]
+[0.0, 0.763183652525721, 0.1449588854179733, 0.07124982956257188, 0.006869210831244568, 0.005151908123433427, 0.005151908123433427, 0.0017173027078111417, 0.0017173027078111417]
+[0.0, 0.8667660306915714, 0.08183641187896326, 0.03976353654316534, 0.003878006962100062, 0.0029085052215750474, 0.0029085052215750474, 9.695017405250154E-4, 9.695017405250154E-4]
+[0.0, 0.8894105165270351, 0.06973352545251134, 0.030942506624395866, 0.0033044837986859086, 0.0024783628490144317, 0.0024783628490144317, 8.261209496714769E-4, 8.261209496714769E-4]
+[0.0, 0.9259370484172332, 0.04933589138761051, 0.01771337548355612, 0.0023378949038667207, 0.0017534211779000409, 0.0017534211779000409, 5.844737259666801E-4, 5.844737259666801E-4]
+[0.0, 0.9007697513989619, 0.06378696393111567, 0.02637520783701041, 0.003022692277637358, 0.0022670192082280168, 0.0022670192082280168, 7.556730694093394E-4, 7.556730694093394E-4]
+[1.0, 0.20104301443785033, 0.4962889599579836, 0.23211463753125175, 0.0235177960243049, 0.017638347018228678, 0.017638347018228678, 0.005879449006076224, 0.005879449006076224]
+[0.0, 0.8313305510503194, 0.10731838717612398, 0.04609447452560074, 0.005085529082652047, 0.0038141468119890355, 0.0038141468119890355, 0.0012713822706630115, 0.0012713822706630115]
+[0.0, 0.7575028415910264, 0.15257573514686312, 0.0682309648379732, 0.0072301528080457, 0.005422614606034277, 0.005422614606034277, 0.0018075382020114248, 0.0018075382020114248]
+[0.0, 0.9273172031323027, 0.048299788835054806, 0.017516617642237723, 0.0022887967968015753, 0.0017165975976011817, 0.0017165975976011817, 5.721991992003937E-4, 5.721991992003937E-4]
+[0.0, 0.890727914747982, 0.0715346933139717, 0.027567883072717233, 0.003389836288442973, 0.0025423772163322297, 0.0025423772163322297, 8.47459072110743E-4, 8.47459072110743E-4]
+[0.0, 0.7925365001835079, 0.12350966150065987, 0.06639546853193058, 0.00585278992796732, 0.00438959244597549, 0.00438959244597549, 0.0014631974819918298, 0.0014631974819918298]
+[0.0, 0.801693936457196, 0.1301414694024576, 0.04966343385681251, 0.006167053427844602, 0.0046252900708834525, 0.0046252900708834525, 0.0015417633569611503, 0.0015417633569611503]
+[0.0, 0.6611357709121536, 0.20810252944199317, 0.10117744590803246, 0.009861417912606885, 0.007396063434455165, 0.007396063434455165, 0.002465354478151721, 0.002465354478151721]
+[0.0, 0.7073665515508859, 0.18252161586813165, 0.08416421045952721, 0.008649207373818392, 0.006486905530363796, 0.006486905530363796, 0.002162301843454598, 0.002162301843454598]
+[0.0, 0.5598907292335481, 0.26470993051553615, 0.13776767007232066, 0.012543890059531751, 0.009407917544648816, 0.009407917544648816, 0.0031359725148829374, 0.0031359725148829374]
+[0.0, 0.6068089264303909, 0.24017264378952205, 0.11887502722844721, 0.011381134183879918, 0.00853585063790994, 0.00853585063790994, 0.002845283545969979, 0.002845283545969979]
+[0.0, 0.6576919181112636, 0.2076513403591145, 0.10513662969506117, 0.009840037278186905, 0.00738002795864018, 0.00738002795864018, 0.002460009319546726, 0.002460009319546726]
+[0.0, 0.5173462868592219, 0.29481904883409876, 0.14592262426162028, 0.013970680015019712, 0.010478010011264787, 0.010478010011264787, 0.0034926700037549276, 0.0034926700037549276]
+[0.0, 0.7838642787721145, 0.12868196700984041, 0.06916007958703982, 0.006097891543668371, 0.00457341865775128, 0.00457341865775128, 0.0015244728859170925, 0.0015244728859170925]
+[0.0, 0.8936143690668799, 0.0691107403268261, 0.027449975535248108, 0.0032749716903487064, 0.00245622876776153, 0.00245622876776153, 8.187429225871766E-4, 8.187429225871766E-4]
+[0.0, 0.8081883018576377, 0.11419427386322034, 0.061383347824452116, 0.0054113588182299974, 0.0040585191136724985, 0.0040585191136724985, 0.0013528397045574991, 0.0013528397045574991]
+[0.0, 0.8589982491250353, 0.08631450840812249, 0.04241660681023457, 0.004090211885535858, 0.003067658914151894, 0.003067658914151894, 0.0010225529713839645, 0.0010225529713839645]
+[0.0, 0.701703018421696, 0.1831969797635374, 0.08905636866979982, 0.008681211048322209, 0.006510908286241657, 0.006510908286241657, 0.0021703027620805517, 0.0021703027620805517]
+[0.0, 0.8586247812247573, 0.08654306863621643, 0.042529021923099854, 0.004101042738642155, 0.0030757820539816165, 0.0030757820539816165, 0.0010252606846605386, 0.0010252606846605386]
+[0.0, 0.9302926468767176, 0.04654654096499197, 0.01654366683949707, 0.0022057151062645232, 0.0016542863296983925, 0.0016542863296983925, 5.514287765661307E-4, 5.514287765661307E-4]
+[0.0, 0.7238572091845684, 0.17211803371780307, 0.07955612811932668, 0.008156209659433932, 0.00611715724457545, 0.00611715724457545, 0.0020390524148584826, 0.0020390524148584826]
+[0.0, 0.7543230288312557, 0.14060930446613124, 0.0850783789588327, 0.00666309591459342, 0.004997321935945066, 0.004997321935945066, 0.0016657739786483548, 0.0016657739786483548]
+[0.0, 0.6704206171081577, 0.18730776092036225, 0.11564359231230348, 0.008876009886392165, 0.006657007414794126, 0.006657007414794126, 0.0022190024715980413, 0.0022190024715980413]
+[0.0, 0.8749293872394028, 0.07659212743999325, 0.03759000194377993, 0.00362949445894147, 0.0027221208442061028, 0.0027221208442061028, 9.073736147353675E-4, 9.073736147353675E-4]
+[0.0, 0.8423072602651822, 0.0929745687933187, 0.05150072835816596, 0.0044058141944444814, 0.0033043606458333617, 0.0033043606458333617, 0.0011014535486111204, 0.0011014535486111204]
+[0.0, 0.8635147017504947, 0.08230322413584869, 0.042481690303788455, 0.0039001279366226603, 0.0029250959524669954, 0.0029250959524669954, 9.750319841556648E-4, 9.750319841556648E-4]
+[0.0, 0.7691692960133107, 0.13394602997126398, 0.07784265012235107, 0.006347341297691388, 0.004760505973268543, 0.004760505973268543, 0.0015868353244228469, 0.0015868353244228469]
+[0.0, 0.7080757098279223, 0.17054584306327714, 0.09713332376194111, 0.008081707782286413, 0.006061280836714812, 0.006061280836714812, 0.0020204269455716033, 0.0020204269455716033]
+[0.0, 0.9283764424626327, 0.047246812206595025, 0.017660048112477622, 0.0022388990727648084, 0.0016791743045736064, 0.0016791743045736064, 5.59724768191202E-4, 5.59724768191202E-4]
+[0.0, 0.8423072602651822, 0.0929745687933187, 0.05150072835816596, 0.0044058141944444814, 0.0033043606458333617, 0.0033043606458333617, 0.0011014535486111204, 0.0011014535486111204]
+[0.0, 0.8579410889727471, 0.08512432307290921, 0.04483315132211337, 0.004033812210743508, 0.0030253591580576313, 0.0030253591580576313, 0.0010084530526858768, 0.0010084530526858768]
+[0.0, 0.8480128630084021, 0.09474775360606712, 0.04376986145666949, 0.004489840642953719, 0.00336738048221529, 0.00336738048221529, 0.0011224601607384295, 0.0011224601607384295]
+[0.0, 0.8715105645333588, 0.07820709097496037, 0.03916427480889463, 0.003706023227595248, 0.0027795174206964365, 0.0027795174206964365, 9.265058068988119E-4, 9.265058068988119E-4]
+[0.0, 0.9190225638217445, 0.05260794844043575, 0.020890641135324045, 0.002492948867498609, 0.0018697116506239553, 0.0018697116506239553, 6.232372168746521E-4, 6.232372168746521E-4]
+[0.0, 0.7607144276505207, 0.13790456752949778, 0.08177622765395334, 0.006534925722009378, 0.004901194291507035, 0.004901194291507035, 0.0016337314305023443, 0.0016337314305023443]
+[0.0, 0.6187316790327414, 0.209691616728086, 0.1417665428124384, 0.009936720475578085, 0.007452540356683565, 0.007452540356683565, 0.002484180118894521, 0.002484180118894521]
+[0.0, 0.8604340569225638, 0.08494716319868864, 0.04254252863318772, 0.004025417081853349, 0.0030190628113900123, 0.0030190628113900123, 0.0010063542704633372, 0.0010063542704633372]
+[0.0, 0.39060949895102703, 0.28454808603314685, 0.28439051469347915, 0.013483966774115744, 0.01011297508058681, 0.01011297508058681, 0.0033709916935289355, 0.0033709916935289355]
+[0.0, 0.32410238874200303, 0.32005461227239135, 0.3103434229601951, 0.015166525341803563, 0.011374894006352675, 0.011374894006352675, 0.0037916313354508903, 0.0037916313354508903]
+[0.0, 0.3686465118443232, 0.3099956666535439, 0.2772882444311844, 0.014689859023649601, 0.011017394267737204, 0.011017394267737204, 0.0036724647559124, 0.0036724647559124]
+[0.0, 0.8262011024078381, 0.10834138649065657, 0.05005549231374127, 0.005134006262588142, 0.0038505046969411075, 0.0038505046969411075, 0.0012835015656470353, 0.0012835015656470353]
+[0.0, 0.8846862173591272, 0.07146644975517445, 0.033687525655254846, 0.003386602410147749, 0.0025399518076108124, 0.0025399518076108124, 8.46650602536937E-4, 8.46650602536937E-4]
+[0.0, 0.7900327278127183, 0.12420207132506234, 0.06810839677292697, 0.005885601363097572, 0.00441420102232318, 0.00441420102232318, 0.0014714003407743927, 0.0014714003407743927]
+[0.0, 0.8560537537910332, 0.08625494120276003, 0.04542913753748057, 0.004087389156242081, 0.0030655418671815616, 0.0030655418671815616, 0.0010218472890605203, 0.0010218472890605203]
+[0.0, 0.8644333943612321, 0.0820050970464077, 0.04190350709991892, 0.0038860004974803778, 0.0029145003731102835, 0.0029145003731102835, 9.715001243700944E-4, 9.715001243700944E-4]
+[0.0, 0.9021367278931384, 0.062056738512003766, 0.02698442891788189, 0.00294070155899194, 0.0022055261692439554, 0.0022055261692439554, 7.351753897479849E-4, 7.351753897479849E-4]
+[0.0, 0.8671287600657308, 0.0806247453802654, 0.04078472649538023, 0.0038205893528744377, 0.002865442014655829, 0.002865442014655829, 9.551473382186093E-4, 9.551473382186093E-4]
+[0.0, 0.8087099009136334, 0.11498833578068127, 0.059954801489569574, 0.005448987272038632, 0.004086740454028975, 0.004086740454028975, 0.0013622468180096577, 0.0013622468180096577]
+[0.0, 0.7448506821913511, 0.14893380831631067, 0.08504279435435218, 0.00705757171266202, 0.005293178784496516, 0.005293178784496516, 0.0017643929281655048, 0.0017643929281655048]
+[0.0, 0.8490080664814948, 0.09500634441590591, 0.042479305409462625, 0.00450209456437898, 0.0033765709232842353, 0.0033765709232842353, 0.0011255236410947448, 0.0011255236410947448]
+[0.0, 0.7108620037975302, 0.17116683867514876, 0.09363775225615768, 0.00811113509038777, 0.006083351317790829, 0.006083351317790829, 0.002027783772596942, 0.002027783772596942]
+[0.0, 0.6243365150573758, 0.2073828822341072, 0.13879865539463507, 0.009827315771293978, 0.007370486828470485, 0.007370486828470485, 0.002456828942823494, 0.002456828942823494]
+[0.0, 0.7293414555383863, 0.1521807484116795, 0.0968434896957796, 0.007211435451384893, 0.005408576588538671, 0.005408576588538671, 0.0018028588628462231, 0.0018028588628462231]
+[0.0, 0.8480128630084021, 0.09474775360606712, 0.04376986145666949, 0.004489840642953719, 0.00336738048221529, 0.00336738048221529, 0.0011224601607384295, 0.0011224601607384295]
+[0.0, 0.8616894835588927, 0.08340357164153679, 0.043050133483052824, 0.003952270438839147, 0.0029642028291293606, 0.0029642028291293606, 9.880676097097866E-4, 9.880676097097866E-4]
+[0.0, 0.9021367278931384, 0.062056738512003766, 0.02698442891788189, 0.00294070155899194, 0.0022055261692439554, 0.0022055261692439554, 7.351753897479849E-4, 7.351753897479849E-4]
+[0.0, 0.8649106157100348, 0.08566243919859878, 0.037249008841156526, 0.004059312083403235, 0.0030444840625524264, 0.0030444840625524264, 0.0010148280208508084, 0.0010148280208508084]
+[0.0, 0.7618630532833828, 0.13223590892123807, 0.08710212798266727, 0.006266303270903961, 0.004699727453177972, 0.004699727453177972, 0.00156657581772599, 0.00156657581772599]
+[0.0, 0.7303677509486699, 0.15214929776518687, 0.09585311601606684, 0.0072099450900254365, 0.005407458817519079, 0.005407458817519079, 0.001802486272506359, 0.001802486272506359]
+[0.0, 0.6311371914159333, 0.2051412250660915, 0.1345583144759509, 0.00972108968067476, 0.007290817260506071, 0.007290817260506071, 0.0024302724201686896, 0.0024302724201686896]
+[0.0, 0.8384602023032732, 0.10040863468740042, 0.04685687939525718, 0.004758094538023062, 0.003568570903517297, 0.003568570903517297, 0.0011895236345057653, 0.0011895236345057653]
+[0.0, 0.8831493163406035, 0.07153379154858361, 0.03514751144217671, 0.003389793556212015, 0.002542345167159012, 0.002542345167159012, 8.474483890530038E-4, 8.474483890530038E-4]
+[0.0, 0.8441752277967827, 0.09217512457909562, 0.05054585555981963, 0.004367930688100715, 0.003275948016075537, 0.003275948016075537, 0.0010919826720251786, 0.0010919826720251786]
+[0.0, 0.7451480954137986, 0.15282966932438605, 0.08029567706916166, 0.007242186064217849, 0.005431639548163388, 0.005431639548163388, 0.001810546516054462, 0.001810546516054462]
+[0.0, 0.8414411131932329, 0.09804844810645412, 0.046571683726220316, 0.004646251658030938, 0.003484688743523204, 0.003484688743523204, 0.0011615629145077342, 0.0011615629145077342]
+[0.0, 0.9202549109101111, 0.05194175505976496, 0.020419194753219325, 0.0024613797589681983, 0.001846034819226149, 0.001846034819226149, 6.153449397420495E-4, 6.153449397420495E-4]
+[0.0, 0.7814259473435172, 0.12812152456746506, 0.07223852702788783, 0.006071333687043347, 0.004553500265282511, 0.004553500265282511, 0.0015178334217608364, 0.0015178334217608364]
+[0.0, 0.6729116944070127, 0.18654831747229417, 0.11401992239509989, 0.0088400219085311, 0.006630016431398326, 0.006630016431398326, 0.0022100054771327744, 0.0022100054771327744]
+[0.0, 0.6461451455908063, 0.19895750163119014, 0.12661317369049907, 0.009428059695834805, 0.007071044771876106, 0.007071044771876106, 0.0023570149239587014, 0.0023570149239587014]
+[0.0, 0.8606248929586215, 0.08911059320734244, 0.037596381412760095, 0.004222710807092127, 0.0031670331053190955, 0.0031670331053190955, 0.0010556777017730315, 0.0010556777017730315]
+[0.0, 0.7476068400767373, 0.14394742496171278, 0.08798189362145585, 0.006821280446698034, 0.005115960335023526, 0.005115960335023526, 0.0017053201116745082, 0.0017053201116745082]
+[0.0, 0.6676926002021457, 0.18885755771498489, 0.11660149034621915, 0.008949450578883376, 0.006712087934162534, 0.006712087934162534, 0.0022373626447208437, 0.0022373626447208437]
+[0.0, 0.874080959289902, 0.07687773689790746, 0.03811221764838661, 0.0036430287212680136, 0.0027322715409510106, 0.0027322715409510106, 9.107571803170033E-4, 9.107571803170033E-4]
+[0.0, 0.8697761577274742, 0.07926249129612185, 0.03969324356471635, 0.003756035803895882, 0.002817026852921912, 0.002817026852921912, 9.390089509739704E-4, 9.390089509739704E-4]
+[0.0, 0.8607525806627588, 0.0837047283835977, 0.04364306661848652, 0.003966541445052407, 0.0029749060837893056, 0.0029749060837893056, 9.916353612631017E-4, 9.916353612631017E-4]
+[0.0, 0.7281319094326992, 0.15491859991340476, 0.09492596609205924, 0.007341174853945576, 0.005505881140459183, 0.005505881140459183, 0.0018352937134863939, 0.0018352937134863939]
+[0.0, 0.7561179842107794, 0.14006827665321003, 0.08390136494123701, 0.006637458064924482, 0.004978093548693363, 0.004978093548693363, 0.0016593645162311203, 0.0016593645162311203]
+[0.0, 0.6828732209281276, 0.1821347969485815, 0.10909935091952047, 0.008630877067923431, 0.006473157800942575, 0.006473157800942575, 0.0021577192669808573, 0.0021577192669808573]
+[0.0, 0.8038456149707196, 0.11716449432199434, 0.062333562029400026, 0.0055521095592953994, 0.004164082169471551, 0.004164082169471551, 0.0013880273898238496, 0.0013880273898238496]
+[0.0, 0.8293120456302283, 0.10452778046738675, 0.05130030464327335, 0.004953289753037108, 0.003714967314777832, 0.003714967314777832, 0.0012383224382592768, 0.0012383224382592768]
+[0.0, 0.8218204848416977, 0.10907503111308929, 0.05359816893427756, 0.005168771703645227, 0.003876578777733921, 0.003876578777733921, 0.0012921929259113066, 0.0012921929259113066]
+[0.0, 0.8513900298972532, 0.08848070049922822, 0.04755068393477051, 0.004192861889582696, 0.0031446464171870224, 0.0031446464171870224, 0.0010482154723956737, 0.0010482154723956737]
+[0.0, 0.8831493163406035, 0.07153379154858361, 0.03514751144217671, 0.003389793556212015, 0.002542345167159012, 0.002542345167159012, 8.474483890530038E-4, 8.474483890530038E-4]
+[0.0, 0.6268589615139699, 0.19663866984430392, 0.14854783911755245, 0.009318176508057907, 0.006988632381043433, 0.006988632381043433, 0.002329544127014477, 0.002329544127014477]
+[0.0, 0.7847498573890284, 0.12689839338263914, 0.07031163083659436, 0.0060133727972461245, 0.004510029597934595, 0.004510029597934595, 0.001503343199311531, 0.001503343199311531]
+[0.0, 0.8638038792444028, 0.08778314845620762, 0.035933551963669444, 0.004159806778573405, 0.0031198550839300543, 0.0031198550839300543, 0.001039951694643351, 0.001039951694643351]
+[0.0, 0.8226602317930164, 0.10794023266911312, 0.05405454554488489, 0.005114996664328637, 0.0038362474982464785, 0.0038362474982464785, 0.0012787491660821591, 0.0012787491660821591]
+[0.0, 0.8798978097499075, 0.07399361992507046, 0.035589495748116096, 0.0035063581923020708, 0.0026297686442265534, 0.0026297686442265534, 8.765895480755175E-4, 8.765895480755175E-4]
+[0.0, 0.7807717405602049, 0.12881709758907747, 0.0720982767980294, 0.006104295017562718, 0.004578221263172039, 0.004578221263172039, 0.0015260737543906792, 0.0015260737543906792]
+[0.0, 0.745601351489842, 0.14509082168478538, 0.08868143801952176, 0.006875462935283628, 0.005156597201462722, 0.005156597201462722, 0.0017188657338209068, 0.0017188657338209068]
+[0.0, 0.6439313101763111, 0.19947944451561803, 0.12823086582150858, 0.009452793162187455, 0.007089594871640593, 0.007089594871640593, 0.002363198290546864, 0.002363198290546864]
+[0.0, 0.8475394284101767, 0.0919338975976782, 0.047457175217049015, 0.004356499591698706, 0.00326737469377403, 0.00326737469377403, 0.0010891248979246764, 0.0010891248979246764]
+[0.0, 0.7847498573890284, 0.12689839338263914, 0.07031163083659436, 0.0060133727972461245, 0.004510029597934595, 0.004510029597934595, 0.001503343199311531, 0.001503343199311531]
+[0.0, 0.77558992803973, 0.1323084061686316, 0.07329244963153149, 0.00626973872003559, 0.004702304040026693, 0.004702304040026693, 0.0015674346800088972, 0.0015674346800088972]
+[0.0, 0.8336154310148981, 0.10311653096928801, 0.04860879468542688, 0.0048864144434624225, 0.003664810832596817, 0.003664810832596817, 0.0012216036108656054, 0.0012216036108656054]
+[0.0, 0.9178978480266885, 0.05375111238934071, 0.020709678607338994, 0.00254712032554386, 0.0019103402441578952, 0.0019103402441578952, 6.367800813859649E-4, 6.367800813859649E-4]
+[0.0, 0.787708645690112, 0.12096879237741606, 0.07412540696445068, 0.005732384989340514, 0.004299288742005386, 0.004299288742005386, 0.0014330962473351283, 0.0014330962473351283]
+[0.0, 0.7942582538145696, 0.12259106365746737, 0.0657229023709577, 0.0058092600523351945, 0.004356945039251397, 0.004356945039251397, 0.0014523150130837984, 0.0014523150130837984]
+[0.0, 0.6897775809898907, 0.18001352737991166, 0.1046178241668303, 0.008530355821122442, 0.006397766865841833, 0.006397766865841833, 0.00213258895528061, 0.00213258895528061]
+[0.0, 0.6789443108340055, 0.1818197806704177, 0.11338806060861539, 0.008615949295653786, 0.0064619619717403405, 0.0064619619717403405, 0.002153987323913446, 0.002153987323913446]
+[0.0, 0.6941882906129458, 0.17502924655000274, 0.10589997027264356, 0.008294164188135935, 0.006220623141101953, 0.006220623141101953, 0.0020735410470339834, 0.0020735410470339834]
+[0.0, 0.8560537537910332, 0.08625494120276003, 0.04542913753748057, 0.004087389156242081, 0.0030655418671815616, 0.0030655418671815616, 0.0010218472890605203, 0.0010218472890605203]
+[0.0, 0.8502171067669073, 0.08917885201401232, 0.04792620499525153, 0.004225945407942933, 0.0031694590559572006, 0.0031694590559572006, 0.001056486351985733, 0.001056486351985733]
+[0.0, 0.8410760255869716, 0.09370028867908556, 0.05190307342316464, 0.004440204103592754, 0.0033301530776945693, 0.0033301530776945693, 0.0011100510258981882, 0.0011100510258981882]
+[0.0, 0.7931735340060102, 0.12244155823541285, 0.06697838157841232, 0.00580217539338831, 0.004351631545041234, 0.004351631545041234, 0.0014505438483470774, 0.0014505438483470774]
+[0.0, 0.6729116944070127, 0.18654831747229417, 0.11401992239509989, 0.0088400219085311, 0.006630016431398326, 0.006630016431398326, 0.0022100054771327744, 0.0022100054771327744]
+[0.0, 0.8431237686066825, 0.09249329771494288, 0.051233909512335356, 0.004383008055346406, 0.0032872560415098053, 0.0032872560415098053, 0.0010957520138366013, 0.0010957520138366013]
+[0.0, 0.8892994470451493, 0.06900997625872413, 0.03187998643778912, 0.0032701967527792673, 0.0024526475645844504, 0.0024526475645844504, 8.175491881948167E-4, 8.175491881948167E-4]
+[0.0, 0.8831493163406035, 0.07153379154858361, 0.03514751144217671, 0.003389793556212015, 0.002542345167159012, 0.002542345167159012, 8.474483890530038E-4, 8.474483890530038E-4]
+[0.0, 0.8538404587750525, 0.09164190761042952, 0.04148964469465952, 0.004342662973286247, 0.0032569972299646855, 0.0032569972299646855, 0.0010856657433215616, 0.0010856657433215616]
+[0.0, 0.8787366570469742, 0.07537341859351512, 0.035174694963997395, 0.003571743131837772, 0.0026788073488783295, 0.0026788073488783295, 8.929357829594429E-4, 8.929357829594429E-4]
+[0.0, 0.7905440202065734, 0.12318626694518639, 0.06875731745307954, 0.00583746513172031, 0.004378098848790234, 0.004378098848790234, 0.0014593662829300773, 0.0014593662829300773]
+[0.0, 0.774592596399834, 0.13080000490803534, 0.07601261974118026, 0.00619825965031679, 0.004648694737737593, 0.004648694737737593, 0.0015495649125791973, 0.0015495649125791973]
+[0.0, 0.84198480924829, 0.09793091885278858, 0.04616222510839265, 0.004640682263509593, 0.003480511697632195, 0.003480511697632195, 0.001160170565877398, 0.001160170565877398]
+[0.0, 0.8233720169093679, 0.10344796161539623, 0.05847366133008818, 0.004902120048382662, 0.003676590036286997, 0.003676590036286997, 0.0012255300120956652, 0.0012255300120956652]
+[0.0, 0.8662280210288336, 0.08091979899397375, 0.041348466532333095, 0.00383457114828656, 0.0028759283612149198, 0.0028759283612149198, 9.586427870716397E-4, 9.586427870716397E-4]
+[0.0, 0.9129893003822656, 0.055933603438311136, 0.023125468099616988, 0.0026505426932687108, 0.0019879070199515314, 0.0019879070199515314, 6.626356733171776E-4, 6.626356733171776E-4]
+[0.0, 0.7282239546272895, 0.15059440752825148, 0.09977284874536045, 0.007136263033032822, 0.0053521972747746175, 0.0053521972747746175, 0.001784065758258205, 0.001784065758258205]
+[0.0, 0.7282239546272895, 0.15059440752825148, 0.09977284874536045, 0.007136263033032822, 0.0053521972747746175, 0.0053521972747746175, 0.001784065758258205, 0.001784065758258205]
+[0.0, 0.8585227609478056, 0.08504476086459949, 0.04434235227111996, 0.004030041972158251, 0.003022531479118689, 0.003022531479118689, 0.0010075104930395626, 0.0010075104930395626]
+[0.0, 0.8588964575185454, 0.08482018463159183, 0.04422515812034303, 0.004019399909839901, 0.0030145499323799264, 0.0030145499323799264, 0.001004849977459975, 0.001004849977459975]
+[0.0, 0.8846862173591272, 0.07146644975517445, 0.033687525655254846, 0.003386602410147749, 0.0025399518076108124, 0.0025399518076108124, 8.46650602536937E-4, 8.46650602536937E-4]
+[0.0, 0.8749293872394028, 0.07659212743999325, 0.03759000194377993, 0.00362949445894147, 0.0027221208442061028, 0.0027221208442061028, 9.073736147353675E-4, 9.073736147353675E-4]
+[0.0, 0.9204806423530303, 0.05179475548321215, 0.02036136062790304, 0.0024544138452849257, 0.0018408103839636944, 0.0018408103839636944, 6.136034613212313E-4, 6.136034613212313E-4]
+[0.0, 0.8749293872394028, 0.07659212743999325, 0.03759000194377993, 0.00362949445894147, 0.0027221208442061028, 0.0027221208442061028, 9.073736147353675E-4, 9.073736147353675E-4]
+[0.0, 0.6173737473584044, 0.19566580570513134, 0.1591442216396483, 0.009272075098938595, 0.006954056324203948, 0.006954056324203948, 0.002318018774734648, 0.002318018774734648]
+[0.0, 0.8072763787760798, 0.11584980837217188, 0.060404382443813076, 0.005489810135978464, 0.0041173576019838485, 0.0041173576019838485, 0.0013724525339946158, 0.0013724525339946158]
+[0.0, 0.9060978880625337, 0.05987459788258364, 0.025515626664768126, 0.0028372957967049946, 0.002127971847528746, 0.002127971847528746, 7.093239491762485E-4, 7.093239491762485E-4]
+[0.0, 0.7101917257580523, 0.16397302448798098, 0.10252453087122244, 0.007770239627581412, 0.005827679720686061, 0.005827679720686061, 0.0019425599068953528, 0.0019425599068953528]
+[0.0, 0.855174886412364, 0.08814731944463548, 0.044146602562814906, 0.004177063860061861, 0.0031327978950463965, 0.0031327978950463965, 0.0010442659650154653, 0.0010442659650154653]
+[0.0, 0.9364374385077204, 0.04244413592046011, 0.015084486003086296, 0.002011313189577623, 0.0015084848921832186, 0.0015084848921832186, 5.028282973944056E-4, 5.028282973944056E-4]
+[0.0, 0.8766048918508891, 0.07556632030269281, 0.03708613517485868, 0.003580884223853127, 0.0026856631678898457, 0.0026856631678898457, 8.952210559632815E-4, 8.952210559632815E-4]
+[0.0, 0.723430630293686, 0.15704168195474194, 0.0972023417847503, 0.007441781988940598, 0.00558133649170545, 0.00558133649170545, 0.0018604454972351494, 0.0018604454972351494]
+[0.0, 0.8041737875561066, 0.1170592087343102, 0.062125642632280355, 0.005547120359101093, 0.0041603402693258205, 0.0041603402693258205, 0.001386780089775273, 0.001386780089775273]
+[0.0, 0.7492499824949295, 0.15084674663829778, 0.078458608757002, 0.00714822070325689, 0.005361165527442669, 0.005361165527442669, 0.0017870551758142222, 0.0017870551758142222]
+[0.0, 0.589721823868793, 0.22983512083900529, 0.14776925478148217, 0.01089126683690648, 0.008168450127679862, 0.008168450127679862, 0.00272281670922662, 0.00272281670922662]
+[0.0, 0.589721823868793, 0.22983512083900529, 0.14776925478148217, 0.01089126683690648, 0.008168450127679862, 0.008168450127679862, 0.00272281670922662, 0.00272281670922662]
+[0.0, 0.7880520233187736, 0.1290945230881371, 0.06450112920067023, 0.006117441464139684, 0.004588081098104764, 0.004588081098104764, 0.0015293603660349207, 0.0015293603660349207]
+[0.0, 0.7161713510969904, 0.17234434783463656, 0.08698349884222638, 0.008166934075382175, 0.0061252005565366335, 0.0061252005565366335, 0.002041733518845544, 0.002041733518845544]
+[0.0, 0.894148878529612, 0.06947587836381691, 0.026498419313585875, 0.0032922745976617994, 0.002469205948246352, 0.002469205948246352, 8.230686494154497E-4, 8.230686494154497E-4]
+[0.0, 0.47660933916893866, 0.2705128723191814, 0.21442116102399517, 0.012818875829294987, 0.009614156871971242, 0.009614156871971242, 0.0032047189573237464, 0.0032047189573237464]
+[0.0, 0.5248181127388198, 0.2536517358299268, 0.18547053536626493, 0.012019872021662784, 0.00901490401624709, 0.00901490401624709, 0.0030049680054156955, 0.0030049680054156955]
+[0.0, 0.4584944759290317, 0.27639687707734023, 0.22581553813174604, 0.013097702953960694, 0.009823277215470523, 0.009823277215470523, 0.003274425738490173, 0.003274425738490173]
+[0.0, 0.6319060411368222, 0.20169015515984368, 0.1377311453619445, 0.009557552780463188, 0.007168164585347392, 0.007168164585347392, 0.002389388195115797, 0.002389388195115797]
+[0.0, 0.4392746030016167, 0.28502966583699474, 0.23517536853274337, 0.013506787542881744, 0.01013009065716131, 0.01013009065716131, 0.003376696885720435, 0.003376696885720435]
+[0.0, 0.5656418899461396, 0.2235940530330896, 0.17897749865006873, 0.010595519456900671, 0.007946639592675506, 0.007946639592675506, 0.0026488798642251674, 0.0026488798642251674]
+[0.0, 0.8892994470451493, 0.06900997625872413, 0.03187998643778912, 0.0032701967527792673, 0.0024526475645844504, 0.0024526475645844504, 8.175491881948167E-4, 8.175491881948167E-4]
+[0.0, 0.7896745588571289, 0.1300599780104146, 0.06177588782112882, 0.006163191770442498, 0.004622393827831875, 0.004622393827831875, 0.0015407979426106243, 0.0015407979426106243]
+[0.0, 0.9170948255261024, 0.053719809201684, 0.021548454416630072, 0.0025456369518611502, 0.001909227713895863, 0.001909227713895863, 6.364092379652874E-4, 6.364092379652874E-4]
+[0.0, 0.808052578716099, 0.11510708923332708, 0.06047648801642485, 0.005454614678049724, 0.004090961008537294, 0.004090961008537294, 0.0013636536695124308, 0.0013636536695124308]
+[0.0, 0.6729116944070127, 0.18654831747229417, 0.11401992239509989, 0.0088400219085311, 0.006630016431398326, 0.006630016431398326, 0.0022100054771327744, 0.0022100054771327744]
+[0.0, 0.7963465652253459, 0.12124207287361442, 0.06517535685482483, 0.005745335015405083, 0.004309001261553813, 0.004309001261553813, 0.0014363337538512706, 0.0014363337538512706]
+[0.0, 0.9021367278931384, 0.062056738512003766, 0.02698442891788189, 0.00294070155899194, 0.0022055261692439554, 0.0022055261692439554, 7.351753897479849E-4, 7.351753897479849E-4]
+[0.0, 0.8671059968826789, 0.08432731571989857, 0.036578554855370905, 0.003996044180683836, 0.0029970331355128775, 0.0029970331355128775, 9.99011045170959E-4, 9.99011045170959E-4]
+[0.0, 0.8088286430726543, 0.12028981914309507, 0.05378090695026656, 0.005700210277994778, 0.004275157708496085, 0.004275157708496085, 0.0014250525694986943, 0.0014250525694986943]
+[0.0, 0.8827771573681495, 0.07243515994422989, 0.0344901617633155, 0.00343250697476833, 0.0025743802310762482, 0.0025743802310762482, 8.581267436920824E-4, 8.581267436920824E-4]
+[0.0, 0.7847824449438464, 0.12647229011138433, 0.07076572220931528, 0.005993180911818111, 0.004494885683863584, 0.004494885683863584, 0.0014982952279545276, 0.0014982952279545276]
+[0.0, 0.7997396305623985, 0.11932593818278307, 0.06397082758229841, 0.005654534557506762, 0.0042409009181300725, 0.0042409009181300725, 0.0014136336393766903, 0.0014136336393766903]
+[0.0, 0.4571876822624467, 0.2805750815927915, 0.22235014573501, 0.013295696803250696, 0.009971772602438023, 0.009971772602438023, 0.0033239242008126736, 0.0033239242008126736]
+[0.0, 0.9107618996679714, 0.057365146156172483, 0.02371781524437819, 0.002718379643825886, 0.0020387847328694145, 0.0020387847328694145, 6.795949109564714E-4, 6.795949109564714E-4]
+[0.0, 0.5411847417397619, 0.23715573594719053, 0.18794500915237503, 0.011238171053557441, 0.008428628290168085, 0.008428628290168085, 0.0028095427633893603, 0.0028095427633893603]
+[0.0, 0.5291226597545292, 0.2413756972499743, 0.19518721206217562, 0.011438143644440244, 0.008578607733330185, 0.008578607733330185, 0.0028595359111100605, 0.0028595359111100605]
+[0.0, 0.8815157636131876, 0.07299706130980534, 0.035109773179513255, 0.003459133965831161, 0.002594350474373371, 0.002594350474373371, 8.647834914577901E-4, 8.647834914577901E-4]
+[0.0, 0.8043191260027366, 0.11725504236091155, 0.06175663047601231, 0.005556400386779928, 0.004167300290084947, 0.004167300290084947, 0.0013891000966949818, 0.0013891000966949818]
+[0.0, 0.7691692960133107, 0.13394602997126398, 0.07784265012235107, 0.006347341297691388, 0.004760505973268543, 0.004760505973268543, 0.0015868353244228469, 0.0015868353244228469]
+[0.0, 0.6463581594949813, 0.19812041257740537, 0.12735625102155618, 0.009388392302019002, 0.0070412942265142536, 0.0070412942265142536, 0.0023470980755047506, 0.0023470980755047506]
+[0.0, 0.7934459917630711, 0.12337440481238336, 0.06564046199022941, 0.005846380478105531, 0.004384785358579149, 0.004384785358579149, 0.0014615951195263825, 0.0014615951195263825]
+[0.0, 0.8294897189094038, 0.10438143346731568, 0.05128978333369802, 0.004946354763194232, 0.003709766072395674, 0.003709766072395674, 0.0012365886907985577, 0.0012365886907985577]
+[0.0, 0.8874150867558949, 0.06998043787938867, 0.03265592242564867, 0.0033161843130226714, 0.002487138234767004, 0.002487138234767004, 8.290460782556676E-4, 8.290460782556676E-4]
+[0.0, 0.8723756384597544, 0.08159930323858278, 0.03442474523332749, 0.0038667710227784625, 0.002900078267083847, 0.002900078267083847, 9.666927556946155E-4, 9.666927556946155E-4]
+[0.0, 0.9286422195715274, 0.047071525242207604, 0.017594477098195793, 0.002230592696023056, 0.001672944522017294, 0.001672944522017294, 5.576481740057639E-4, 5.576481740057639E-4]
+[0.0, 0.8831493163406035, 0.07153379154858361, 0.03514751144217671, 0.003389793556212015, 0.002542345167159012, 0.002542345167159012, 8.474483890530038E-4, 8.474483890530038E-4]
+[0.0, 0.8790829596131209, 0.07427278365160771, 0.03608549570889064, 0.0035195870087936635, 0.0026396902565952477, 0.0026396902565952477, 8.798967521984157E-4, 8.798967521984157E-4]
+[0.0, 0.6571152192635408, 0.19348549947612825, 0.1218930124685031, 0.009168756263942634, 0.006876567197956976, 0.006876567197956976, 0.002292189065985658, 0.002292189065985658]
+[0.0, 0.7520326352147916, 0.14191972998880437, 0.08587205445314781, 0.006725193447752085, 0.0050438950858140656, 0.0050438950858140656, 0.0016812983619380211, 0.0016812983619380211]
+[0.0, 0.8761681461025322, 0.07580642774905694, 0.03724863934289051, 0.0035922622685067625, 0.0026941967013800723, 0.0026941967013800723, 8.980655671266904E-4, 8.980655671266904E-4]
+[0.0, 0.4887966535856813, 0.26176911663293806, 0.21222063133085045, 0.012404532816843457, 0.009303399612632594, 0.009303399612632594, 0.0031011332042108638, 0.0031011332042108638]
+[0.0, 0.5009205095326205, 0.25769732243027915, 0.20474742364078402, 0.012211581465438852, 0.009158686099079142, 0.009158686099079142, 0.0030528953663597124, 0.0030528953663597124]
+[0.0, 0.7099849245779333, 0.16306005776649024, 0.10377408786869374, 0.0077269765956275785, 0.005795232446720685, 0.005795232446720685, 0.0019317441489068942, 0.0019317441489068942]
+[0.0, 0.6129206934219346, 0.21526776994905591, 0.14120865859180215, 0.010200959345735791, 0.007650719509301846, 0.007650719509301846, 0.0025502398364339474, 0.0025502398364339474]
+[0.0, 0.7832176596242105, 0.12739154964700258, 0.0712805642989752, 0.006036742143270645, 0.004527556607452985, 0.004527556607452985, 0.001509185535817661, 0.001509185535817661]
+[0.0, 0.8107375124826566, 0.11585773187790416, 0.05693419881076958, 0.005490185609556649, 0.004117639207167487, 0.004117639207167487, 0.001372546402389162, 0.001372546402389162]
+[0.0, 0.8440229627943505, 0.09666807972617239, 0.045566438315316364, 0.0045808397213869855, 0.003435629791040239, 0.003435629791040239, 0.001145209930346746, 0.001145209930346746]
+[0.0, 0.8893752279697716, 0.0689627461768072, 0.031858149913891944, 0.0032679586465098336, 0.002450968984882373, 0.002450968984882373, 8.169896616274583E-4, 8.169896616274583E-4]
+[0.0, 0.8607525806627588, 0.0837047283835977, 0.04364306661848652, 0.003966541445052407, 0.0029749060837893056, 0.0029749060837893056, 9.916353612631017E-4, 9.916353612631017E-4]
+[0.0, 0.9343902958816428, 0.043705891545877285, 0.015690499409982232, 0.0020711043874990787, 0.001553328290624308, 0.001553328290624308, 5.177760968747696E-4, 5.177760968747696E-4]
+[0.0, 0.8287244884750319, 0.104646654912565, 0.05175208793472848, 0.004958922892558166, 0.003719192169418626, 0.003719192169418626, 0.0012397307231395414, 0.0012397307231395414]
+[0.0, 0.7362023619201757, 0.15718509980574752, 0.08426680375116159, 0.007448578174305027, 0.005586433630728771, 0.005586433630728771, 0.0018621445435762565, 0.0018621445435762565]
+[0.0, 0.901402642666642, 0.0650403858822314, 0.024310705755533093, 0.003082088565197776, 0.0023115664238983324, 0.0023115664238983324, 7.705221412994439E-4, 7.705221412994439E-4]
+[0.0, 0.8732399056316393, 0.0775985572152743, 0.038129977793855345, 0.003677186453077007, 0.0027578898398077554, 0.0027578898398077554, 9.192966132692516E-4, 9.192966132692516E-4]
+[0.0, 0.7535387274925837, 0.13694068684746924, 0.09005283561582186, 0.006489250014708466, 0.004866937511031351, 0.004866937511031351, 0.0016223125036771162, 0.0016223125036771162]
+[0.0, 0.7436952215840309, 0.14720055285716985, 0.08817791333303716, 0.006975437408587358, 0.0052315780564405195, 0.0052315780564405195, 0.0017438593521468392, 0.0017438593521468392]
+[0.0, 0.6307136086109183, 0.20688123341239142, 0.13299452601908363, 0.009803543985868923, 0.007352657989401694, 0.007352657989401694, 0.00245088599646723, 0.00245088599646723]
+[0.0, 0.8728757491542344, 0.07782142589381591, 0.038239582154973695, 0.0036877475989920637, 0.002765810699244048, 0.002765810699244048, 9.219368997480157E-4, 9.219368997480157E-4]
+[0.0, 0.8749293872394028, 0.07659212743999325, 0.03759000194377993, 0.00362949445894147, 0.0027221208442061028, 0.0027221208442061028, 9.073736147353675E-4, 9.073736147353675E-4]
+[0.0, 0.8963149440428801, 0.06538082610791882, 0.02900956651977642, 0.0030982211098082037, 0.0023236658323561536, 0.0023236658323561536, 7.745552774520508E-4, 7.745552774520508E-4]
+[0.0, 0.879571938375902, 0.0741943358980943, 0.03568611698235275, 0.0035158695812170983, 0.0026369021859128238, 0.0026369021859128238, 8.789673953042744E-4, 8.789673953042744E-4]
+[0.0, 0.8749293872394028, 0.07659212743999325, 0.03759000194377993, 0.00362949445894147, 0.0027221208442061028, 0.0027221208442061028, 9.073736147353675E-4, 9.073736147353675E-4]
+[0.0, 0.9031245678615741, 0.06210651004583712, 0.025939741799137668, 0.0029430600978170005, 0.0022072950733627505, 0.0022072950733627505, 7.3576502445425E-4, 7.3576502445425E-4]
+[0.0, 0.7585072368427093, 0.14001555686393918, 0.08157232684468713, 0.006634959816221507, 0.0049762198621661315, 0.0049762198621661315, 0.0016587399540553766, 0.0016587399540553766]
+[0.0, 0.857388792480498, 0.09017934799553547, 0.03961179087720468, 0.004273356215587313, 0.0032050171616904845, 0.0032050171616904845, 0.001068339053896828, 0.001068339053896828]
+[0.0, 0.8461903369014133, 0.09098345971921439, 0.04989182067150464, 0.004311460902622531, 0.0032335956769668985, 0.0032335956769668985, 0.0010778652256556325, 0.0010778652256556325]
+[0.0, 0.8959014738065517, 0.06545615192940386, 0.0293370024717207, 0.003101790597441373, 0.0023263429480810303, 0.0023263429480810303, 7.754476493603432E-4, 7.754476493603432E-4]
+[0.0, 0.9135722005710842, 0.05570730968796071, 0.022801032013655062, 0.002639819242433199, 0.001979864431824899, 0.001979864431824899, 6.599548106082995E-4, 6.599548106082995E-4]
+[0.0, 0.9463097272583154, 0.03652379263652124, 0.011974187864777046, 0.0017307640801287132, 0.0012980730600965363, 0.0012980730600965363, 4.3269102003217825E-4, 4.3269102003217825E-4]
+[0.0, 0.8671287600657308, 0.0806247453802654, 0.04078472649538023, 0.0038205893528744377, 0.002865442014655829, 0.002865442014655829, 9.551473382186093E-4, 9.551473382186093E-4]
+[0.0, 0.9232991290970335, 0.05021565823308901, 0.019346458620309724, 0.0023795846831893568, 0.0017846885123920194, 0.0017846885123920194, 5.948961707973391E-4, 5.948961707973391E-4]
+[0.0, 0.8881927827432594, 0.07030213713743826, 0.03151079379821873, 0.0033314287736945806, 0.0024985715802709357, 0.0024985715802709357, 8.32857193423645E-4, 8.32857193423645E-4]
+[0.0, 0.8368323777080804, 0.09556667964953243, 0.05401500062037601, 0.004528647340670385, 0.003396485505502789, 0.003396485505502789, 0.0011321618351675961, 0.0011321618351675961]
+[0.0, 0.9367346880035436, 0.04224568333055034, 0.015013901497043982, 0.0020019090562872354, 0.0015014317922154268, 0.0015014317922154268, 5.004772640718087E-4, 5.004772640718087E-4]
+[0.0, 0.7582828541212088, 0.13954494849435076, 0.08233422052198858, 0.006612658954150651, 0.004959494215612989, 0.004959494215612989, 0.0016531647385376626, 0.0016531647385376626]
+[0.0, 0.5840922768574117, 0.22442491325632669, 0.15957813483657998, 0.010634891683227149, 0.007976168762420363, 0.007976168762420363, 0.0026587229208067872, 0.0026587229208067872]
+[0.0, 0.6082412022908272, 0.20145089400435895, 0.16166925918705458, 0.009546214839253081, 0.007159661129439812, 0.007159661129439812, 0.00238655370981327, 0.00238655370981327]
+[0.0, 0.6140015606363001, 0.1993142237725518, 0.1583493242015288, 0.009444963796539781, 0.007083722847404838, 0.007083722847404838, 0.002361240949134945, 0.002361240949134945]
+[0.0, 0.8823649974296981, 0.07343801391597878, 0.033756900090683294, 0.003480029521213351, 0.0026100221409100137, 0.0026100221409100137, 8.700073803033377E-4, 8.700073803033377E-4]
+[0.0, 0.8644333943612321, 0.0820050970464077, 0.04190350709991892, 0.0038860004974803778, 0.0029145003731102835, 0.0029145003731102835, 9.715001243700944E-4, 9.715001243700944E-4]
+[0.0, 0.6862077484494267, 0.1725777115853726, 0.11668056230176622, 0.008177992554478188, 0.006133494415858642, 0.006133494415858642, 0.002044498138619547, 0.002044498138619547]
+[0.0, 0.8694268966371415, 0.07947501893965686, 0.03979976367509041, 0.0037661069160370964, 0.002824580187027822, 0.002824580187027822, 9.415267290092739E-4, 9.415267290092739E-4]
+[0.0, 0.8465330973428975, 0.0910767350119779, 0.04944252474317866, 0.004315880967315298, 0.0032369107254864742, 0.0032369107254864742, 0.0010789702418288244, 0.0010789702418288244]
+[0.0, 0.8282149260747252, 0.10488046638331629, 0.05199459977826231, 0.004970002587898834, 0.003727501940924126, 0.003727501940924126, 0.0012425006469747083, 0.0012425006469747083]
+[0.0, 0.8959014738065517, 0.06545615192940386, 0.0293370024717207, 0.003101790597441373, 0.0023263429480810303, 0.0023263429480810303, 7.754476493603432E-4, 7.754476493603432E-4]
+[0.0, 0.8550796658682551, 0.08656200911840829, 0.04605250418222391, 0.004101940277037587, 0.0030764552077781906, 0.0030764552077781906, 0.0010254850692593966, 0.0010254850692593966]
+[0.0, 0.8740445713073633, 0.07710609030374768, 0.03788778906801347, 0.003653849773625215, 0.0027403873302189116, 0.0027403873302189116, 9.134624434063035E-4, 9.134624434063035E-4]
+[0.0, 0.8579410889727471, 0.08512432307290921, 0.04483315132211337, 0.004033812210743508, 0.0030253591580576313, 0.0030253591580576313, 0.0010084530526858768, 0.0010084530526858768]
+[0.0, 0.8717863546232468, 0.0782783088329303, 0.03880714239409067, 0.003709398049910792, 0.002782048537433094, 0.002782048537433094, 9.273495124776978E-4, 9.273495124776978E-4]
+[0.0, 0.8715105645333588, 0.07820709097496037, 0.03916427480889463, 0.003706023227595248, 0.0027795174206964365, 0.0027795174206964365, 9.265058068988119E-4, 9.265058068988119E-4]
+[0.0, 0.8831493163406035, 0.07153379154858361, 0.03514751144217671, 0.003389793556212015, 0.002542345167159012, 0.002542345167159012, 8.474483890530038E-4, 8.474483890530038E-4]
+[0.0, 0.8764170524635637, 0.08007643540796594, 0.032122692864563956, 0.0037946064213022295, 0.0028459548159766724, 0.0028459548159766724, 9.486516053255572E-4, 9.486516053255572E-4]
+[0.0, 0.8461903369014133, 0.09098345971921439, 0.04989182067150464, 0.004311460902622531, 0.0032335956769668985, 0.0032335956769668985, 0.0010778652256556325, 0.0010778652256556325]
+[0.0, 0.8732370417440761, 0.07760030995383545, 0.03813083977019006, 0.003677269510632767, 0.0027579521329745755, 0.0027579521329745755, 9.193173776581916E-4, 9.193173776581916E-4]
+[0.0, 0.9000980496817357, 0.06317291961270531, 0.02774824758777301, 0.002993594372595341, 0.0022451957794465058, 0.0022451957794465058, 7.483985931488351E-4, 7.483985931488351E-4]
+[0.0, 0.7896003755401457, 0.12526784080407313, 0.06732346773826814, 0.00593610530583776, 0.0044520789793783214, 0.0044520789793783214, 0.0014840263264594398, 0.0014840263264594398]
+[0.0, 0.7764401281104237, 0.13223998672848053, 0.07252039563950426, 0.006266496507197114, 0.004699872380397836, 0.004699872380397836, 0.0015666241267992783, 0.0015666241267992783]
+[0.0, 0.8997793282816708, 0.06372731619511658, 0.02743375832657137, 0.0030198657322137853, 0.0022648992991603396, 0.0022648992991603396, 7.549664330534462E-4, 7.549664330534462E-4]
+[0.0, 0.8357524261258031, 0.10119109842672404, 0.04867095529117219, 0.004795173385433627, 0.00359638003907522, 0.00359638003907522, 0.0011987933463584064, 0.0011987933463584064]
+[0.0, 0.8846862173591272, 0.07146644975517445, 0.033687525655254846, 0.003386602410147749, 0.0025399518076108124, 0.0025399518076108124, 8.46650602536937E-4, 8.46650602536937E-4]
+[0.0, 0.8751062272554657, 0.07648385949812089, 0.037536821447349544, 0.0036243639330213687, 0.002718272949766027, 0.002718272949766027, 9.060909832553422E-4, 9.060909832553422E-4]
+[0.0, 0.865678986023803, 0.08150422145559472, 0.041229996460451834, 0.0038622653533835023, 0.0028966990150376274, 0.0028966990150376274, 9.655663383458754E-4, 9.655663383458754E-4]
+[0.0, 0.5188460454190903, 0.24741982789117445, 0.1985604505805231, 0.011724558703070664, 0.008793419027303, 0.008793419027303, 0.0029311396757676655, 0.0029311396757676655]
+[0.0, 0.5548991330415236, 0.23456475813100047, 0.17718993403034375, 0.011115391599044058, 0.008336543699283045, 0.008336543699283045, 0.002778847899761014, 0.002778847899761014]
+[0.0, 0.8277756363139444, 0.10642014024286578, 0.05067533269783764, 0.0050429635817841375, 0.0037822226863381036, 0.0037822226863381036, 0.0012607408954460342, 0.0012607408954460342]
+[0.0, 0.890806455286609, 0.06807073928526065, 0.03144573889493631, 0.0032256888443980922, 0.002419266633298567, 0.002419266633298567, 8.064222110995228E-4, 8.064222110995228E-4]
+[0.0, 0.774592596399834, 0.13080000490803534, 0.07601261974118026, 0.00619825965031679, 0.004648694737737593, 0.004648694737737593, 0.0015495649125791973, 0.0015495649125791973]
+[1.0, 0.31737101229420883, 0.33109320417013344, 0.3044669401664686, 0.015689614456396443, 0.011767210842297336, 0.011767210842297336, 0.003922403614099111, 0.003922403614099111]
+[0.0, 0.8226602317930164, 0.10794023266911312, 0.05405454554488489, 0.005114996664328637, 0.0038362474982464785, 0.0038362474982464785, 0.0012787491660821591, 0.0012787491660821591]
+[0.0, 0.8544938314495306, 0.0871894173940196, 0.04592173676448656, 0.004131671463987701, 0.003098753597990776, 0.003098753597990776, 0.001032917865996925, 0.001032917865996925]
+[0.0, 0.6121310231862281, 0.19848382622203156, 0.16116831010666172, 0.009405613495026182, 0.0070542101212696376, 0.0070542101212696376, 0.002351403373756545, 0.002351403373756545]
+[0.0, 0.6245317636597666, 0.19387945563684703, 0.1540265063500137, 0.00918742478445755, 0.006890568588343165, 0.006890568588343165, 0.002296856196114387, 0.002296856196114387]
+[0.0, 0.46982548508762506, 0.2740468994170699, 0.21716858395370395, 0.012986343847200411, 0.00973975788540031, 0.00973975788540031, 0.0032465859618001024, 0.0032465859618001024]
+[0.0, 0.886392251973956, 0.07361427718243434, 0.02952832435677463, 0.0034883821622784085, 0.0026162866217088066, 0.0026162866217088066, 8.720955405696019E-4, 8.720955405696019E-4]
+[0.0, 0.8461903369014133, 0.09098345971921439, 0.04989182067150464, 0.004311460902622531, 0.0032335956769668985, 0.0032335956769668985, 0.0010778652256556325, 0.0010778652256556325]
+[0.0, 0.8001448658065791, 0.11899166566174163, 0.0639473856802978, 0.005638694283793947, 0.0042290207128454615, 0.0042290207128454615, 0.0014096735709484866, 0.0014096735709484866]
+[0.0, 0.8644333943612321, 0.0820050970464077, 0.04190350709991892, 0.0038860004974803778, 0.0029145003731102835, 0.0029145003731102835, 9.715001243700944E-4, 9.715001243700944E-4]
+[0.0, 0.8616894835588927, 0.08340357164153679, 0.043050133483052824, 0.003952270438839147, 0.0029642028291293606, 0.0029642028291293606, 9.880676097097866E-4, 9.880676097097866E-4]
+[0.0, 0.8576278106360162, 0.08638825259287751, 0.04370281750010251, 0.004093706423667826, 0.00307027981775087, 0.00307027981775087, 0.0010234266059169564, 0.0010234266059169564]
+[0.0, 0.7997618805488806, 0.12074474859149043, 0.06232806638486689, 0.005721768158254128, 0.004291326118690597, 0.004291326118690597, 0.0014304420395635318, 0.0014304420395635318]
+[0.0, 0.7861295003696853, 0.1260963151048526, 0.06984809111627108, 0.005975364469730425, 0.0044815233522978205, 0.0044815233522978205, 0.001493841117432606, 0.001493841117432606]
+[0.0, 0.7689102450053966, 0.13713835170907518, 0.07445555282649424, 0.006498616819677922, 0.004873962614758443, 0.004873962614758443, 0.0016246542049194804, 0.0016246542049194804]
+[0.0, 0.8293120456302283, 0.10452778046738675, 0.05130030464327335, 0.004953289753037108, 0.003714967314777832, 0.003714967314777832, 0.0012383224382592768, 0.0012383224382592768]
+[0.0, 0.9311216162728072, 0.045660752721933366, 0.01672641103783395, 0.0021637399891417416, 0.0016228049918563063, 0.0016228049918563063, 5.409349972854353E-4, 5.409349972854353E-4]
+[0.0, 0.8298780862772103, 0.10418123432646131, 0.051130075799640996, 0.00493686786556255, 0.003702650899171916, 0.003702650899171916, 0.001234216966390637, 0.001234216966390637]
+[0.0, 0.8885486448550077, 0.0692760099888561, 0.032326935033733344, 0.0032828033741342097, 0.0024621025306006575, 0.0024621025306006575, 8.207008435335523E-4, 8.207008435335523E-4]
+[0.0, 0.8594716438983263, 0.08861349234135653, 0.03931740014922808, 0.004199154537029721, 0.0031493659027722913, 0.0031493659027722913, 0.00104978863425743, 0.00104978863425743]
+[0.0, 0.8616894835588927, 0.08340357164153679, 0.043050133483052824, 0.003952270438839147, 0.0029642028291293606, 0.0029642028291293606, 9.880676097097866E-4, 9.880676097097866E-4]
+[0.0, 0.8989591237958648, 0.06389295420392224, 0.028064777387332804, 0.003027714870960078, 0.002270786153220059, 0.002270786153220059, 7.569287177400194E-4, 7.569287177400194E-4]
+[0.0, 0.8635147017504947, 0.08230322413584869, 0.042481690303788455, 0.0039001279366226603, 0.0029250959524669954, 0.0029250959524669954, 9.750319841556648E-4, 9.750319841556648E-4]
+[0.0, 0.8426322013721956, 0.0929354602532825, 0.051220455536064274, 0.004403960946152483, 0.0033029707096143626, 0.0033029707096143626, 0.0011009902365381205, 0.0011009902365381205]
+[0.0, 0.777682510314451, 0.12932737508702594, 0.07460468752043779, 0.006128475692695126, 0.004596356769521345, 0.004596356769521345, 0.0015321189231737812, 0.0015321189231737812]
+[0.0, 0.886392251973956, 0.07361427718243434, 0.02952832435677463, 0.0034883821622784085, 0.0026162866217088066, 0.0026162866217088066, 8.720955405696019E-4, 8.720955405696019E-4]
+[0.0, 0.8560537537910332, 0.08625494120276003, 0.04542913753748057, 0.004087389156242081, 0.0030655418671815616, 0.0030655418671815616, 0.0010218472890605203, 0.0010218472890605203]
+[0.0, 0.8229745576627002, 0.10774896602322942, 0.05395867715340484, 0.005105933053555335, 0.003829449790166502, 0.003829449790166502, 0.0012764832633888334, 0.0012764832633888334]
+[0.0, 0.8215232562839465, 0.10829801840281994, 0.0547828718158102, 0.005131951165807847, 0.003848963374355886, 0.003848963374355886, 0.0012829877914519614, 0.0012829877914519614]
+[0.0, 0.7533743549758959, 0.1406591468298618, 0.08597012476467311, 0.006665457809856382, 0.004999093357392288, 0.004999093357392288, 0.0016663644524640953, 0.0016663644524640953]
+[0.0, 0.6692797710396101, 0.18729085072145732, 0.11680375256598574, 0.008875208557648907, 0.0066564064182366815, 0.0066564064182366815, 0.0022188021394122263, 0.0022188021394122263]
+[0.0, 0.8980198338075603, 0.06430601571490506, 0.028532284249962615, 0.00304728874252395, 0.0022854665568929626, 0.0022854665568929626, 7.618221856309873E-4, 7.618221856309873E-4]
+[0.0, 0.8255754781415916, 0.107138009898058, 0.052055567491351346, 0.005076981489666431, 0.003807736117249824, 0.003807736117249824, 0.0012692453724166075, 0.0012692453724166075]
+[0.0, 0.7577317790998758, 0.13865901238106043, 0.08389717802949533, 0.006570676829856186, 0.00492800762239214, 0.00492800762239214, 0.0016426692074640462, 0.0016426692074640462]
+[0.0, 0.7387201178204804, 0.14584784660832473, 0.09469802665383506, 0.006911336305786613, 0.005183502229339961, 0.005183502229339961, 0.001727834076446653, 0.001727834076446653]
+[0.0, 0.8255754781415916, 0.107138009898058, 0.052055567491351346, 0.005076981489666431, 0.003807736117249824, 0.003807736117249824, 0.0012692453724166075, 0.0012692453724166075]
+[0.0, 0.8831493163406035, 0.07153379154858361, 0.03514751144217671, 0.003389793556212015, 0.002542345167159012, 0.002542345167159012, 8.474483890530038E-4, 8.474483890530038E-4]
+[0.0, 0.7584327971050496, 0.13958157611986544, 0.0821424428593119, 0.006614394638590986, 0.00496079597894324, 0.00496079597894324, 0.0016535986596477462, 0.0016535986596477462]
+[0.0, 0.857413147547561, 0.08991121305018648, 0.03989368933233044, 0.004260650023307236, 0.003195487517480427, 0.003195487517480427, 0.0010651625058268087, 0.0010651625058268087]
+[0.0, 0.8373298821190066, 0.10036885776882602, 0.0480326312609459, 0.0047562096170738095, 0.0035671572128053585, 0.0035671572128053585, 0.0011890524042684524, 0.0011890524042684524]
+[0.0, 0.7385861679914725, 0.14804061997232323, 0.09232747426209277, 0.007015245924703808, 0.005261434443527857, 0.005261434443527857, 0.0017538114811759516, 0.0017538114811759516]
+[0.0, 0.6729116944070127, 0.18654831747229417, 0.11401992239509989, 0.0088400219085311, 0.006630016431398326, 0.006630016431398326, 0.0022100054771327744, 0.0022100054771327744]
+[0.0, 0.6126361895414221, 0.19919201192758465, 0.1598542810110763, 0.009439172506638964, 0.0070793793799792245, 0.0070793793799792245, 0.0023597931266597406, 0.0023597931266597406]
+[0.0, 0.5355287513606897, 0.24082723412266002, 0.18940755415085603, 0.011412153455264725, 0.008559115091448546, 0.008559115091448546, 0.0028530383638161808, 0.0028530383638161808]
+[0.0, 0.8169812386345403, 0.11173709081400508, 0.05539691194024903, 0.005294919537068642, 0.003971189652801482, 0.003971189652801482, 0.0013237298842671602, 0.0013237298842671602]
+[0.0, 0.5095870674192404, 0.2510420126843097, 0.2036823070668976, 0.011896204276517445, 0.008922153207388086, 0.008922153207388086, 0.0029740510691293608, 0.0029740510691293608]
+[0.0, 0.534266711128812, 0.24247177343370782, 0.1887912642168112, 0.011490083740223003, 0.008617562805167255, 0.008617562805167255, 0.00287252093505575, 0.00287252093505575]
+[0.0, 0.7755259630894479, 0.1311402109481972, 0.07469068266983551, 0.006214381097506429, 0.004660785823129823, 0.004660785823129823, 0.001553595274376607, 0.001553595274376607]
+[0.0, 0.6910086637725712, 0.17868960618755053, 0.10489887374621037, 0.008467618764555962, 0.006350714073416973, 0.006350714073416973, 0.0021169046911389904, 0.0021169046911389904]
+[0.0, 0.9415767669992263, 0.03938188323054719, 0.013442745902749189, 0.0018662012891590698, 0.0013996509668693013, 0.0013996509668693013, 4.6655032228976734E-4, 4.6655032228976734E-4]
+[0.0, 0.874712739107955, 0.07669716135386949, 0.037686684339197946, 0.0036344717329924287, 0.002725853799744322, 0.002725853799744322, 9.086179332481071E-4, 9.086179332481071E-4]
+[0.0, 0.8774364011462747, 0.07528392108953524, 0.036577171505073676, 0.0035675020863721197, 0.00267562656477909, 0.00267562656477909, 8.918755215930298E-4, 8.918755215930298E-4]
+[0.0, 0.8746283290818572, 0.07674882162020528, 0.037712089976658675, 0.0036369197737595466, 0.002727689830319661, 0.002727689830319661, 9.092299434398867E-4, 9.092299434398867E-4]
+[0.0, 0.8153305067335349, 0.11170766616261286, 0.05708125155738518, 0.005293525182155756, 0.003970143886616818, 0.003970143886616818, 0.0013233812955389388, 0.0013233812955389388]
+[0.0, 0.8087099009136334, 0.11498833578068127, 0.059954801489569574, 0.005448987272038632, 0.004086740454028975, 0.004086740454028975, 0.0013622468180096577, 0.0013622468180096577]
+[0.0, 0.9050608988364516, 0.06020288218385514, 0.02617766206521938, 0.0028528523048246554, 0.002139639228618492, 0.002139639228618492, 7.132130762061638E-4, 7.132130762061638E-4]
+[0.0, 0.8182294937977154, 0.1053889530154024, 0.061399257990706016, 0.004994098398725453, 0.0037455737990440903, 0.0037455737990440903, 0.001248524599681363, 0.001248524599681363]
+[0.0, 0.6926358044895796, 0.16713798137115976, 0.11646555893064715, 0.007920218402871156, 0.005940163802153368, 0.005940163802153368, 0.0019800546007177886, 0.0019800546007177886]
+[0.0, 0.7105427675080792, 0.1685375589857353, 0.09696005166614072, 0.007986540613348208, 0.005989905460011157, 0.005989905460011157, 0.0019966351533370515, 0.0019966351533370515]
+[0.0, 0.7837910397000434, 0.12663333799260615, 0.07157318469697697, 0.006000812536791276, 0.004500609402593458, 0.004500609402593458, 0.0015002031341978187, 0.0015002031341978187]
+[0.0, 0.8655706690903843, 0.08106376223617467, 0.041841389138632216, 0.003841393178269586, 0.0028810448837021897, 0.0028810448837021897, 9.603482945673963E-4, 9.603482945673963E-4]
+[0.0, 0.8512248774057978, 0.08829310734277412, 0.04793009818471431, 0.004183972355571269, 0.0031379792666784527, 0.0031379792666784527, 0.001045993088892817, 0.001045993088892817]
+[0.0, 0.7920455949860221, 0.12260927930810936, 0.06791475597711676, 0.0058101232429173194, 0.004357592432187991, 0.004357592432187991, 0.0014525308107293296, 0.0014525308107293296]
+[0.0, 0.8787541812022611, 0.0742504384041861, 0.03643979601029704, 0.003518528127751825, 0.00263889609581387, 0.00263889609581387, 8.796320319379563E-4, 8.796320319379563E-4]
+[0.0, 0.8679672246542092, 0.07986801374545216, 0.04081057195873803, 0.0037847298805335984, 0.002838547410400199, 0.002838547410400199, 9.461824701333994E-4, 9.461824701333994E-4]
+[0.0, 0.7467689826163693, 0.14991674817468575, 0.08200181746008171, 0.007104150582954403, 0.0053281129372158035, 0.0053281129372158035, 0.0017760376457386005, 0.0017760376457386005]
+[0.0, 0.7831251829486018, 0.12043310246099176, 0.07932071432581321, 0.00570700008819782, 0.004280250066148366, 0.004280250066148366, 0.0014267500220494548, 0.0014267500220494548]
+[0.0, 0.7898855311158984, 0.12388245805165639, 0.06862064357760068, 0.005870455751614984, 0.004402841813711238, 0.004402841813711238, 0.0014676139379037458, 0.0014676139379037458]
+[0.0, 0.8602008913367638, 0.08456468030203451, 0.04321255161601528, 0.00400729224839532, 0.0030054691862964906, 0.0030054691862964906, 0.0010018230620988298, 0.0010018230620988298]
+[0.0, 0.868081899314987, 0.07979866397555935, 0.04077510596382405, 0.0037814435818764452, 0.002836082686407334, 0.002836082686407334, 9.453608954691111E-4, 9.453608954691111E-4]
+[0.0, 0.8512248774057978, 0.08829310734277412, 0.04793009818471431, 0.004183972355571269, 0.0031379792666784527, 0.0031379792666784527, 0.001045993088892817, 0.001045993088892817]
+[0.0, 0.8632803750888759, 0.08218561694355749, 0.04285034342116658, 0.0038945548487999346, 0.0029209161365999514, 0.0029209161365999514, 9.736387121999834E-4, 9.736387121999834E-4]
+[0.0, 0.8660001566581224, 0.08080484033366904, 0.041707632306442546, 0.003829123567255334, 0.0028718426754415012, 0.0028718426754415012, 9.572808918138333E-4, 9.572808918138333E-4]
+[0.0, 0.8900344713739209, 0.06835266872808037, 0.031895713735811584, 0.003239048720729092, 0.002429286540546819, 0.002429286540546819, 8.097621801822729E-4, 8.097621801822729E-4]
+[0.0, 0.84490797159963, 0.0914416394997854, 0.05065087047849821, 0.004333172807362145, 0.003249879605521609, 0.003249879605521609, 0.001083293201840536, 0.001083293201840536]
+[0.0, 0.8735577148784971, 0.07789868666695475, 0.03746937211824334, 0.0036914087787682814, 0.002768556584076211, 0.002768556584076211, 9.228521946920702E-4, 9.228521946920702E-4]
+[0.0, 0.6447300394276609, 0.19539889072555794, 0.13209278969413682, 0.009259426717548102, 0.006944570038161078, 0.006944570038161078, 0.0023148566793870255, 0.0023148566793870255]
+[2.0, 0.12863750997096682, 0.3331137814340364, 0.4908926160960999, 0.015785364166299, 0.011839023124724252, 0.011839023124724252, 0.00394634104157475, 0.00394634104157475]
+[2.0, 0.09743346009963395, 0.3489688294291638, 0.5039876340146336, 0.016536692152189596, 0.0124025191141422, 0.0124025191141422, 0.004134173038047398, 0.004134173038047398]
+[2.0, 0.0887367959007877, 0.34441371418776623, 0.517886977352673, 0.016320837519591156, 0.012240628139693371, 0.012240628139693371, 0.004080209379897789, 0.004080209379897789]
+[2.0, 0.14175335832538533, 0.3525231796334139, 0.45560809235923233, 0.016705123227322875, 0.012528842420492159, 0.012528842420492159, 0.004176280806830718, 0.004176280806830718]
+[2.0, 0.21905704161569825, 0.35693972079039177, 0.37326000397111436, 0.016914411207598613, 0.012685808405698962, 0.012685808405698962, 0.004228602801899652, 0.004228602801899652]
+[2.0, 0.10442258268688429, 0.35212698229473727, 0.4933913895081013, 0.016686348503425815, 0.012514761377569364, 0.012514761377569364, 0.004171587125856453, 0.004171587125856453]
+[2.0, 0.10931260343574105, 0.354100076970205, 0.4862477751696869, 0.016779848141455687, 0.012584886106091767, 0.012584886106091767, 0.004194962035363921, 0.004194962035363921]
+[0.0, 0.7838593875906175, 0.1275358768592758, 0.07047399128766384, 0.006043581420814289, 0.0045326860656107176, 0.0045326860656107176, 0.001510895355203572, 0.001510895355203572]
+[0.0, 0.8707791435677726, 0.07841030132025008, 0.03966359665771302, 0.0037156528180881635, 0.002786739613566123, 0.002786739613566123, 9.289132045220406E-4, 9.289132045220406E-4]
+[0.0, 0.8681612399776832, 0.07975068251318956, 0.0407505678999886, 0.003779169869712755, 0.0028343774022845667, 0.0028343774022845667, 9.447924674281886E-4, 9.447924674281886E-4]
+[0.0, 0.7158147732956529, 0.1676862653166873, 0.09266036108434539, 0.007946200101104799, 0.005959650075828601, 0.005959650075828601, 0.0019865500252761997, 0.0019865500252761997]
+[0.0, 0.8512801022525969, 0.08826034233553497, 0.04791229628127099, 0.004182419710199001, 0.0031368147826492513, 0.0031368147826492513, 0.00104560492754975, 0.00104560492754975]
+[0.0, 0.8680760441336166, 0.0798022049106573, 0.04077691682398822, 0.0037816113772458516, 0.0028362085329343887, 0.0028362085329343887, 9.454028443114627E-4, 9.454028443114627E-4]
+[0.0, 0.7391969249151499, 0.14664134914207075, 0.09331491118705273, 0.0069489382519088636, 0.0052117036889316485, 0.0052117036889316485, 0.0017372345629772157, 0.0017372345629772157]
+[0.0, 0.6250016134312307, 0.2054716363347085, 0.14031650929393022, 0.009736746980043507, 0.007302560235032632, 0.007302560235032632, 0.0024341867450108764, 0.0024341867450108764]
+[0.0, 0.8627523973918557, 0.08250291282625215, 0.04301591784574191, 0.003909590645383436, 0.0029321929840375772, 0.0029321929840375772, 9.773976613458588E-4, 9.773976613458588E-4]
+[0.0, 0.8906359258335056, 0.06797890427604623, 0.03172115879786702, 0.0032213370308603125, 0.002416002773145235, 0.002416002773145235, 8.05334257715078E-4, 8.05334257715078E-4]
+[2.0, 0.13147334382310644, 0.3339173939341683, 0.4871389266532974, 0.01582344519647602, 0.01186758389735702, 0.01186758389735702, 0.003955861299119005, 0.003955861299119005]
+[2.0, 0.14366092517029994, 0.33669898753400174, 0.47177431503823175, 0.015955257419155596, 0.011966443064366698, 0.011966443064366698, 0.003988814354788898, 0.003988814354788898]
+[2.0, 0.12569879765690528, 0.3323391832247729, 0.4947160449828547, 0.015748658045155798, 0.011811493533866851, 0.011811493533866851, 0.003937164511288949, 0.003937164511288949]
+[2.0, 0.15672113777027458, 0.33894758611137044, 0.4561458387849965, 0.016061812444452907, 0.012046359333339682, 0.012046359333339682, 0.004015453111113226, 0.004015453111113226]
+[2.0, 0.09513408778252475, 0.3478885364296569, 0.5075208758509314, 0.01648549997896245, 0.01236412498422184, 0.01236412498422184, 0.004121374994740612, 0.004121374994740612]
+[0.0, 0.7876760830148848, 0.12569506454154425, 0.06875980158215293, 0.005956350287139455, 0.004467262715354592, 0.004467262715354592, 0.0014890875717848634, 0.0014890875717848634]
+[0.0, 0.8599592879199383, 0.08391530507306173, 0.044195846686782364, 0.003976520106739151, 0.0029823900800543634, 0.0029823900800543634, 9.941300266847876E-4, 9.941300266847876E-4]
+[0.0, 0.7108905934150171, 0.17002980299246212, 0.09490784148944253, 0.008057254034359354, 0.006042940525769517, 0.006042940525769517, 0.0020143135085898384, 0.0020143135085898384]
+[0.0, 0.8766176070600427, 0.07888771617364919, 0.03327984810307014, 0.003738276221079367, 0.0028037071658095257, 0.0028037071658095257, 9.345690552698415E-4, 9.345690552698415E-4]
+[0.0, 0.8546912908037008, 0.08651570250832098, 0.04649376889315193, 0.00409974593160886, 0.003074809448706645, 0.003074809448706645, 0.0010249364829022147, 0.0010249364829022147]
+[0.0, 0.8605116543433539, 0.08358440465941705, 0.044021422112910935, 0.003960839628106073, 0.0029706297210795552, 0.0029706297210795552, 9.90209907026518E-4, 9.90209907026518E-4]
+[0.0, 0.780635429900744, 0.1289085183503645, 0.07213017014586769, 0.006108627201007856, 0.0045814704007558936, 0.0045814704007558936, 0.0015271568002519639, 0.0015271568002519639]
+[0.0, 0.8787705884267558, 0.07424039321197805, 0.036434862021753896, 0.003518052113170734, 0.0026385390848780504, 0.0026385390848780504, 8.795130282926833E-4, 8.795130282926833E-4]
+[0.0, 0.8599159575539861, 0.08394126252781683, 0.044209529436548566, 0.003977750160549522, 0.002983312620412142, 0.002983312620412142, 9.944375401373803E-4, 9.944375401373803E-4]
+[0.0, 0.7720818502568072, 0.13214758405683688, 0.07698421230535499, 0.006262117793666994, 0.0046965883452502475, 0.0046965883452502475, 0.0015655294484167484, 0.0015655294484167484]
+[0.0, 0.8517701427630764, 0.08796960018906022, 0.04775433037707181, 0.004168642223597164, 0.003126481667697874, 0.003126481667697874, 0.0010421605558992909, 0.0010421605558992909]
+[0.0, 0.7719098844083933, 0.13145448840716187, 0.07794780560706759, 0.006229273859125775, 0.004671955394344333, 0.004671955394344333, 0.0015573184647814436, 0.0015573184647814436]
+[0.0, 0.3406267289415459, 0.3241256529169296, 0.28916929518916445, 0.015359440984120107, 0.011519580738090082, 0.011519580738090082, 0.0038398602460300263, 0.0038398602460300263]
+[0.0, 0.33318146379222624, 0.311010023417962, 0.31159473282051453, 0.014737926656432485, 0.011053444992324366, 0.011053444992324366, 0.003684481664108121, 0.003684481664108121]
+[0.0, 0.33318146379222624, 0.311010023417962, 0.31159473282051453, 0.014737926656432485, 0.011053444992324366, 0.011053444992324366, 0.003684481664108121, 0.003684481664108121]
+[0.0, 0.356944604904069, 0.30592506272124553, 0.29363944014683885, 0.01449696407594891, 0.010872723056961684, 0.010872723056961684, 0.003624241018987227, 0.003624241018987227]
+[0.0, 0.8026749007932581, 0.11861504316014314, 0.06184751457061779, 0.0056208471586604225, 0.004215635368995318, 0.004215635368995318, 0.0014052117896651054, 0.0014052117896651054]
+[0.0, 0.7912115469055787, 0.12310088216964113, 0.06818731399267351, 0.005833418977368974, 0.004375064233026731, 0.004375064233026731, 0.0014583547443422433, 0.0014583547443422433]
+[0.0, 0.9012318817392699, 0.062281037984404986, 0.027633088757211356, 0.00295133050637118, 0.002213497879778385, 0.002213497879778385, 7.378326265927949E-4, 7.378326265927949E-4]
+[0.0, 0.8680760441336166, 0.0798022049106573, 0.04077691682398822, 0.0037816113772458516, 0.0028362085329343887, 0.0028362085329343887, 9.454028443114627E-4, 9.454028443114627E-4]
+[0.0, 0.8517668760987344, 0.0879715383094624, 0.047755383394107294, 0.0041687340658986575, 0.003126550549423994, 0.003126550549423994, 0.0010421835164746642, 0.0010421835164746642]
+[0.0, 0.7846195057677899, 0.12698632277885027, 0.07034155285042547, 0.006017539534311582, 0.0045131546507336875, 0.0045131546507336875, 0.0015043848835778952, 0.0015043848835778952]
+[0.0, 0.8717197902826598, 0.08201853795033698, 0.03460175948994395, 0.003886637425686517, 0.0029149780692648885, 0.0029149780692648885, 9.71659356421629E-4, 9.71659356421629E-4]
+[0.0, 0.8238781200978395, 0.10686949811144125, 0.05405960947103616, 0.005064257439894482, 0.0037981930799208625, 0.0037981930799208625, 0.0012660643599736203, 0.0012660643599736203]
+[0.0, 0.8569398862012657, 0.08545118653623547, 0.04546102309495016, 0.004049301389182929, 0.0030369760418871975, 0.0030369760418871975, 0.0010123253472957322, 0.0010123253472957322]
+[0.0, 0.8481444073408161, 0.08982788602124017, 0.04925760249788251, 0.004256701380020396, 0.0031925260350152973, 0.0031925260350152973, 0.0010641753450050988, 0.0010641753450050988]
+[0.0, 0.8681612399776832, 0.07975068251318956, 0.0407505678999886, 0.003779169869712755, 0.0028343774022845667, 0.0028343774022845667, 9.447924674281886E-4, 9.447924674281886E-4]
+[0.0, 0.8559553200520569, 0.08603911655329434, 0.04577407797101733, 0.00407716180787717, 0.0030578713559078776, 0.0030578713559078776, 0.0010192904519692922, 0.0010192904519692922]
+[0.0, 0.8784747308870676, 0.07439475280803605, 0.03655441590988014, 0.003525366798338812, 0.002644025098754109, 0.002644025098754109, 8.813416995847028E-4, 8.813416995847028E-4]
+[0.0, 0.8542513755750466, 0.0864974743036086, 0.046954503682975594, 0.004098882146123184, 0.0030741616095923885, 0.0030741616095923885, 0.0010247205365307957, 0.0010247205365307957]
+[0.0, 0.8485824603764958, 0.09328121612586539, 0.04487528734281695, 0.004420345384940521, 0.0033152590387053914, 0.0033152590387053914, 0.0011050863462351301, 0.0011050863462351301]
+[0.0, 0.8542700039775727, 0.086766464388945, 0.04662864504993585, 0.00411162886118216, 0.0030837216458866204, 0.0030837216458866204, 0.0010279072152955399, 0.0010279072152955399]
+[0.0, 0.8453514255426829, 0.09118025494417908, 0.05050596001957053, 0.004320786497855739, 0.003240589873391805, 0.003240589873391805, 0.0010801966244639346, 0.0010801966244639346]
+[0.0, 0.8680760441336166, 0.0798022049106573, 0.04077691682398822, 0.0037816113772458516, 0.0028362085329343887, 0.0028362085329343887, 9.454028443114627E-4, 9.454028443114627E-4]
+[0.0, 0.6463389861246789, 0.18488058261048762, 0.1424974539179896, 0.008760992448947897, 0.006570744336710924, 0.006570744336710924, 0.0021902481122369737, 0.0021902481122369737]
+[0.0, 0.5770875414196219, 0.22376988402805206, 0.16733101971097125, 0.010603851613784894, 0.007952888710338673, 0.007952888710338673, 0.002650962903446223, 0.002650962903446223]
+[0.0, 0.8784774929098204, 0.07439306239158176, 0.03655358461641853, 0.0035252866940597024, 0.002643965020544777, 0.002643965020544777, 8.813216735149254E-4, 8.813216735149254E-4]
+[0.0, 0.8269518742841203, 0.10593461053717833, 0.052053648265249775, 0.0050199556378172526, 0.0037649667283629396, 0.0037649667283629396, 0.001254988909454313, 0.001254988909454313]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.803583524533178, 0.11628061843992223, 0.06360518183548554, 0.00551022506380484, 0.004132668797853631, 0.004132668797853631, 0.0013775562659512099, 0.0013775562659512099]
+[0.0, 0.7019870142176102, 0.17175301826362407, 0.10184322983579613, 0.008138912560989857, 0.006104184420742394, 0.006104184420742394, 0.0020347281402474642, 0.0020347281402474642]
+[0.0, 0.8477689049603102, 0.09063607375847238, 0.04871002362616542, 0.004294999218350672, 0.0032212494137630046, 0.0032212494137630046, 0.0010737498045876677, 0.0010737498045876677]
+[0.0, 0.806527035829771, 0.11556332256871232, 0.061480938563520666, 0.0054762343459987895, 0.004107175759499093, 0.004107175759499093, 0.0013690585864996972, 0.0013690585864996972]
+[0.0, 0.7990185096733239, 0.1192758696584582, 0.06474913483290959, 0.005652161945102872, 0.004239121458827154, 0.004239121458827154, 0.0014130404862757178, 0.0014130404862757178]
+[0.0, 0.7689963444948771, 0.1317522852154422, 0.08052121334827829, 0.006243385647134154, 0.004682539235350617, 0.004682539235350617, 0.0015608464117835383, 0.0015608464117835383]
+[0.0, 0.737998541903588, 0.14571604561108062, 0.09557014064990799, 0.006905090611807748, 0.005178817958855812, 0.005178817958855812, 0.0017262726529519365, 0.0017262726529519365]
+[0.0, 0.8571317501913073, 0.08533661551795824, 0.04540001775834697, 0.004043872177462469, 0.0030329041330968516, 0.0030329041330968516, 0.001010968044365617, 0.001010968044365617]
+[0.0, 0.8900344713739209, 0.06835266872808037, 0.031895713735811584, 0.003239048720729092, 0.002429286540546819, 0.002429286540546819, 8.097621801822729E-4, 8.097621801822729E-4]
+[0.0, 0.7939097374357186, 0.12171012648907471, 0.06707759163151387, 0.005767514814564357, 0.00432563611092327, 0.00432563611092327, 0.0014418787036410891, 0.0014418787036410891]
+[0.0, 0.8542348766216651, 0.08678737317800424, 0.04663989118332768, 0.004112619672334304, 0.003084464754250728, 0.003084464754250728, 0.0010281549180835758, 0.0010281549180835758]
+[0.0, 0.8491729596000608, 0.08921963169355022, 0.048923775165295176, 0.004227877847031222, 0.0031709083852734165, 0.0031709083852734165, 0.0010569694617578052, 0.0010569694617578052]
+[0.0, 0.7913853063615163, 0.12299846529952514, 0.06813053118505674, 0.005828565717967355, 0.004371424288475517, 0.004371424288475517, 0.0014571414294918385, 0.0014571414294918385]
+[0.0, 0.8019488226315351, 0.11791792228666956, 0.06336981764295464, 0.0055878124796137135, 0.004190859359710286, 0.004190859359710286, 0.0013969531199034282, 0.0013969531199034282]
+[0.0, 0.8330610534793886, 0.10223252460564347, 0.05017285062056211, 0.0048445237648018676, 0.0036333928236014007, 0.0036333928236014007, 0.0012111309412004667, 0.0012111309412004667]
+[0.0, 0.8446151278796931, 0.09161424990428867, 0.050746565168580456, 0.004341352349145878, 0.0032560142618594085, 0.0032560142618594085, 0.0010853380872864692, 0.0010853380872864692]
+[0.0, 0.8962532206218563, 0.0650495045710327, 0.029449712781271217, 0.0030825206752798867, 0.0023118905064599153, 0.0023118905064599153, 7.706301688199716E-4, 7.706301688199716E-4]
+[0.0, 0.8415200544403653, 0.09313076922290416, 0.05210952800147647, 0.004413216111751307, 0.0033099120838134804, 0.0033099120838134804, 0.0011033040279378266, 0.0011033040279378266]
+[0.0, 0.8415200544403653, 0.09313076922290416, 0.05210952800147647, 0.004413216111751307, 0.0033099120838134804, 0.0033099120838134804, 0.0011033040279378266, 0.0011033040279378266]
+[0.0, 0.8028400977359563, 0.11738742005682479, 0.06308446198035667, 0.005562673408954184, 0.004172005056715639, 0.004172005056715639, 0.0013906683522385457, 0.0013906683522385457]
+[0.0, 0.8542891753360848, 0.0867550530570977, 0.04662250728003896, 0.00411108810892611, 0.003083316081694583, 0.003083316081694583, 0.0010277720272315273, 0.0010277720272315273]
+[0.0, 0.8540589809328777, 0.0868920712089404, 0.046696204768787566, 0.0041175810297981305, 0.0030881857723485985, 0.0030881857723485985, 0.0010293952574495324, 0.0010293952574495324]
+[0.0, 0.7645483226717779, 0.13470307776034793, 0.08159895231268134, 0.006383215751730896, 0.004787411813798173, 0.004787411813798173, 0.0015958039379327237, 0.0015958039379327237]
+[0.0, 0.6928067907256238, 0.17574676564590014, 0.10646194717660137, 0.008328165483958207, 0.006246124112968657, 0.006246124112968657, 0.0020820413709895513, 0.0020820413709895513]
+[0.0, 0.8733644252748909, 0.07707899733750277, 0.038598879654647505, 0.0036525659109862088, 0.002739424433239657, 0.002739424433239657, 9.131414777465521E-4, 9.131414777465521E-4]
+[0.0, 0.8626946166173183, 0.08253763700086308, 0.04303403799056931, 0.003911236130416351, 0.0029334270978122632, 0.0029334270978122632, 9.778090326040875E-4, 9.778090326040875E-4]
+[0.0, 0.7836866287863303, 0.1266944723646675, 0.07160777025933092, 0.006003709529890486, 0.0045027821474178656, 0.0045027821474178656, 0.0015009273824726213, 0.0015009273824726213]
+[0.0, 0.8550068772694691, 0.09065032852253302, 0.04145577006841388, 0.004295674713194607, 0.0032217560348959556, 0.0032217560348959556, 0.0010739186782986515, 0.0010739186782986515]
+[0.0, 0.8737358126506788, 0.07685300365606787, 0.03848561365443006, 0.003641856679607744, 0.0027313925097058084, 0.0027313925097058084, 9.104641699019358E-4, 9.104641699019358E-4]
+[0.0, 0.8625516819107997, 0.08262353561721354, 0.0430788625690916, 0.003915306634298345, 0.0029364799757237593, 0.0029364799757237593, 9.78826658574586E-4, 9.78826658574586E-4]
+[0.0, 0.8543019806381182, 0.08674743098086463, 0.04661840762317906, 0.004110726919279365, 0.0030830451894595236, 0.0030830451894595236, 0.001027681729819841, 0.001027681729819841]
+[0.0, 0.8485824603764958, 0.09328121612586539, 0.04487528734281695, 0.004420345384940521, 0.0033152590387053914, 0.0033152590387053914, 0.0011050863462351301, 0.0011050863462351301]
+[0.0, 0.8757327038870792, 0.07586954681463055, 0.03761198936564538, 0.0035952533108816113, 0.002696439983161209, 0.002696439983161209, 8.988133277204027E-4, 8.988133277204027E-4]
+[0.0, 0.7476458748021378, 0.142402852494146, 0.08970701074076601, 0.006748087320983393, 0.005061065490737546, 0.005061065490737546, 0.001687021830245848, 0.001687021830245848]
+[0.0, 0.710116368062993, 0.1588358877730322, 0.10846733046525887, 0.007526804566238599, 0.00564510342467895, 0.00564510342467895, 0.0018817011415596494, 0.0018817011415596494]
+[0.0, 0.8519062009295177, 0.08788887651466402, 0.04771047171702383, 0.004164816946264895, 0.003123612709698671, 0.003123612709698671, 0.0010412042365662234, 0.0010412042365662234]
+[0.0, 0.845109670141207, 0.0913227525879569, 0.05058496003959553, 0.004327539077080134, 0.003245654307810101, 0.003245654307810101, 0.0010818847692700333, 0.0010818847692700333]
+[0.0, 0.8631348970412401, 0.08227304413174115, 0.0428959654642764, 0.003898697787580713, 0.002924023340685535, 0.002924023340685535, 9.746744468951781E-4, 9.746744468951781E-4]
+[0.0, 0.8925935579344898, 0.06695693008748022, 0.03093078669138855, 0.0031729084288804606, 0.0023796813216603457, 0.0023796813216603457, 7.93227107220115E-4, 7.93227107220115E-4]
+[0.0, 0.8629559261356265, 0.0823805993097516, 0.04295209094199332, 0.0039037945375427125, 0.002927845903157035, 0.002927845903157035, 9.759486343856779E-4, 9.759486343856779E-4]
+[0.0, 0.8808828984734841, 0.0731674521562015, 0.03554802438409689, 0.0034672083287391967, 0.002600406246554398, 0.002600406246554398, 8.668020821847991E-4, 8.668020821847991E-4]
+[0.0, 0.8808721037535937, 0.07317408114198512, 0.035551247728901614, 0.0034675224585065012, 0.0026006418438798765, 0.0026006418438798765, 8.668806146266251E-4, 8.668806146266251E-4]
+[0.0, 0.8065030037425722, 0.11557767301792514, 0.061488580114190526, 0.005476914375104156, 0.004107685781328118, 0.004107685781328118, 0.0013692285937760389, 0.0013692285937760389]
+[0.0, 0.8339443896284925, 0.1016917171494419, 0.04990720415033375, 0.0048188963572438825, 0.0036141722679329125, 0.0036141722679329125, 0.0012047240893109704, 0.0012047240893109704]
+[0.0, 0.9477199567315444, 0.03560450063043898, 0.011613938708051297, 0.0016872013099884168, 0.0012654009824913136, 0.0012654009824913136, 4.218003274971041E-4, 4.218003274971041E-4]
+[0.0, 0.9067469390802938, 0.059297772875051606, 0.025525403201221236, 0.0028099616144777587, 0.0021074712108583196, 0.0021074712108583196, 7.024904036194396E-4, 7.024904036194396E-4]
+[0.0, 0.8901274043373386, 0.06829491702976821, 0.03186874256263153, 0.0032363120234205774, 0.0024272340175654334, 0.0024272340175654334, 8.090780058551442E-4, 8.090780058551442E-4]
+[0.0, 0.8707098124605359, 0.07845236004840005, 0.03968488988753665, 0.003717645867842398, 0.0027882344008817992, 0.0027882344008817992, 9.294114669605995E-4, 9.294114669605995E-4]
+[0.0, 0.8482667098047203, 0.08975556015874844, 0.04921790787945957, 0.0042532740523572804, 0.003189955539267961, 0.003189955539267961, 0.0010633185130893201, 0.0010633185130893201]
+[0.0, 0.8782281385859511, 0.07457250359041773, 0.03659798803730953, 0.003533789928773886, 0.002650342446580415, 0.002650342446580415, 8.834474821934713E-4, 8.834474821934713E-4]
+[0.0, 0.6617950474710004, 0.17894955048608321, 0.13381559157043052, 0.008479936824161982, 0.006359952618121488, 0.006359952618121488, 0.002119984206040495, 0.002119984206040495]
+[0.0, 0.6286397990836331, 0.19175921571049503, 0.1523401282169804, 0.009086952329630518, 0.00681521424722289, 0.00681521424722289, 0.002271738082407629, 0.002271738082407629]
+[0.0, 0.8456960748991321, 0.0961916601084387, 0.04443747455263588, 0.0045582634799312275, 0.003418697609948421, 0.003418697609948421, 0.0011395658699828067, 0.0011395658699828067]
+[0.0, 0.9335501008589524, 0.04405116798741221, 0.016136332831609024, 0.0020874661073420975, 0.0015655995805065734, 0.0015655995805065734, 5.218665268355243E-4, 5.218665268355243E-4]
+[0.0, 0.8480584617132423, 0.08987871157315933, 0.04928549711583463, 0.004259109865921349, 0.003194332399441012, 0.003194332399441012, 0.001064777466480337, 0.001064777466480337]
+[0.0, 0.7788986913191226, 0.129928786902958, 0.07270159684542946, 0.006156974977496655, 0.004617731233122493, 0.004617731233122493, 0.0015392437443741635, 0.0015392437443741635]
+[0.0, 0.9044604799745514, 0.0609184225985208, 0.02596081791809658, 0.002886759836277056, 0.0021650698772077903, 0.0021650698772077903, 7.216899590692638E-4, 7.216899590692638E-4]
+[0.0, 0.8415200544403653, 0.09313076922290416, 0.05210952800147647, 0.004413216111751307, 0.0033099120838134804, 0.0033099120838134804, 0.0011033040279378266, 0.0011033040279378266]
+[0.0, 0.8589782276075727, 0.08436863014552168, 0.044659136367062896, 0.00399800195994765, 0.0029985014699607376, 0.0029985014699607376, 9.995004899869123E-4, 9.995004899869123E-4]
+[0.0, 0.9105367042468927, 0.0572006086785035, 0.02413093910575314, 0.002710582656283587, 0.0020329369922126904, 0.0020329369922126904, 6.776456640708966E-4, 6.776456640708966E-4]
+[0.0, 0.8038293934158062, 0.11717418076518112, 0.062338720097830695, 0.005552568573727409, 0.004164426430295558, 0.004164426430295558, 0.001388142143431852, 0.001388142143431852]
+[0.0, 0.8464540917435094, 0.0908274839709799, 0.04980621538843309, 0.004304069632359278, 0.0032280522242694597, 0.0032280522242694597, 0.0010760174080898194, 0.0010760174080898194]
+[0.0, 0.8345229751820548, 0.10133748754037875, 0.049733206164789504, 0.004802110370925709, 0.003601582778194282, 0.003601582778194282, 0.001200527592731427, 0.001200527592731427]
+[0.0, 0.8759336756496349, 0.07574687762272778, 0.03755112568201024, 0.0035894403485423353, 0.0026920802614067516, 0.0026920802614067516, 8.973600871355838E-4, 8.973600871355838E-4]
+[0.0, 0.7757328846893127, 0.12430722810810411, 0.08228813382382218, 0.005890584459587081, 0.004417938344690312, 0.004417938344690312, 0.00147264611489677, 0.00147264611489677]
+[0.0, 0.7816120376586412, 0.12672802131462688, 0.07364404305414705, 0.006005299324195081, 0.004503974493146312, 0.004503974493146312, 0.00150132483104877, 0.00150132483104877]
+[0.0, 0.6833536548476896, 0.17996035271978006, 0.1111024843805838, 0.008527836017315518, 0.00639587701298664, 0.00639587701298664, 0.002131959004328879, 0.002131959004328879]
+[0.0, 0.8707098124605359, 0.07845236004840005, 0.03968488988753665, 0.003717645867842398, 0.0027882344008817992, 0.0027882344008817992, 9.294114669605995E-4, 9.294114669605995E-4]
+[0.0, 0.8653943868703644, 0.08117003608389071, 0.04189628941741646, 0.003846429209442867, 0.002884821907082151, 0.002884821907082151, 9.616073023607166E-4, 9.616073023607166E-4]
+[0.0, 0.5524051486380361, 0.23135920334719787, 0.18334518101872974, 0.010963488998678765, 0.008222616749009076, 0.008222616749009076, 0.002740872249669691, 0.002740872249669691]
+[0.0, 0.8569398862012657, 0.08545118653623547, 0.04546102309495016, 0.004049301389182929, 0.0030369760418871975, 0.0030369760418871975, 0.0010123253472957322, 0.0010123253472957322]
+[0.0, 0.5343510185123038, 0.2377000869237224, 0.19415699542699752, 0.011263966378992027, 0.008447974784244023, 0.008447974784244023, 0.002815991594748007, 0.002815991594748007]
+[0.0, 0.5348014031624335, 0.23346984136856364, 0.19853823613366905, 0.011063506445111232, 0.008297629833833425, 0.008297629833833425, 0.0027658766112778075, 0.0027658766112778075]
+[0.0, 0.7627229091480014, 0.1357470564259718, 0.0822319731663359, 0.006432687086563624, 0.004824515314922719, 0.004824515314922719, 0.0016081717716409057, 0.0016081717716409057]
+[0.0, 0.6906502262174704, 0.17698009127738312, 0.10720985412183873, 0.008386609461102527, 0.006289957095826897, 0.006289957095826897, 0.002096652365275632, 0.002096652365275632]
+[0.0, 0.7883919071466605, 0.12383297342838506, 0.07017078699883056, 0.005868110808708067, 0.004401083106531051, 0.004401083106531051, 0.0014670277021770165, 0.0014670277021770165]
+[0.0, 0.7189045825358484, 0.16422160588619023, 0.09352775388804903, 0.0077820192299707484, 0.005836514422478062, 0.005836514422478062, 0.0019455048074926867, 0.0019455048074926867]
+[0.0, 0.8772696755662742, 0.07515931352350072, 0.036886219101101694, 0.0035615972697077836, 0.002671197952280838, 0.002671197952280838, 8.903993174269459E-4, 8.903993174269459E-4]
+[0.0, 0.8376717736721335, 0.09507519093053195, 0.05373696435195758, 0.004505357015125609, 0.0033790177613442066, 0.0033790177613442066, 0.0011263392537814018, 0.0011263392537814018]
+[0.0, 0.6104211390022083, 0.1994973996353116, 0.1617205293417493, 0.00945364400691022, 0.0070902330051826655, 0.0070902330051826655, 0.0023634110017275545, 0.0023634110017275545]
+[0.0, 0.5160794138180402, 0.2469431593211039, 0.2018715148675516, 0.011701970664434734, 0.008776477998326053, 0.008776477998326053, 0.002925492666108683, 0.002925492666108683]
+[0.0, 0.7404656045101599, 0.14645322047166107, 0.09226110499417516, 0.006940023341334602, 0.005205017506000953, 0.005205017506000953, 0.0017350058353336503, 0.0017350058353336503]
+[0.0, 0.7003655021063903, 0.1732804591197554, 0.10172015717639939, 0.008211293865818252, 0.006158470399363691, 0.006158470399363691, 0.002052823466454563, 0.002052823466454563]
+[0.0, 0.8653943868703644, 0.08117003608389071, 0.04189628941741646, 0.003846429209442867, 0.002884821907082151, 0.002884821907082151, 9.616073023607166E-4, 9.616073023607166E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8575429823106847, 0.0850910493005495, 0.04526926201967465, 0.0040322354563636, 0.0030241765922727, 0.0030241765922727, 0.0010080588640908998, 0.0010080588640908998]
+[0.0, 0.8927386320892123, 0.066866512610487, 0.03088898393517982, 0.003168623788373569, 0.0023764678412801768, 0.0023764678412801768, 7.92155947093392E-4, 7.92155947093392E-4]
+[0.0, 0.7952175915682806, 0.12113597618334351, 0.06642551011063948, 0.005740307379245583, 0.004305230534434188, 0.004305230534434188, 0.0014350768448113955, 0.0014350768448113955]
+[0.0, 0.8421489213882171, 0.09276132126836001, 0.051902630436233846, 0.004395708969063103, 0.003296781726797327, 0.003296781726797327, 0.0010989272422657756, 0.0010989272422657756]
+[0.0, 0.904470416642633, 0.060577235280784236, 0.026340572409617832, 0.002870591888988265, 0.0021529439167412012, 0.0021529439167412012, 7.176479722470661E-4, 7.176479722470661E-4]
+[0.0, 0.9068272257579505, 0.059246731484572046, 0.025503414055769707, 0.0028075429005692387, 0.002105657175426931, 0.002105657175426931, 7.018857251423094E-4, 7.018857251423094E-4]
+[0.0, 0.8784747308870676, 0.07439475280803605, 0.03655441590988014, 0.003525366798338812, 0.002644025098754109, 0.002644025098754109, 8.813416995847028E-4, 8.813416995847028E-4]
+[0.0, 0.8832736878980694, 0.07191428532444422, 0.03458855438569386, 0.0034078241305974784, 0.002555868097948109, 0.002555868097948109, 8.519560326493694E-4, 8.519560326493694E-4]
+[0.0, 0.8481444073408161, 0.08982788602124017, 0.04925760249788251, 0.004256701380020396, 0.0031925260350152973, 0.0031925260350152973, 0.0010641753450050988, 0.0010641753450050988]
+[0.0, 0.8297693483257697, 0.10424780681357543, 0.05116277719182942, 0.0049400225562752234, 0.0037050169172064182, 0.0037050169172064182, 0.0012350056390688059, 0.0012350056390688059]
+[0.0, 0.8136630682984837, 0.11201172104607209, 0.05840141008501151, 0.005307933523477701, 0.003980950142608277, 0.003980950142608277, 0.001326983380869425, 0.001326983380869425]
+[0.0, 0.8098261113929658, 0.11395610497008779, 0.06001756572778117, 0.005400072636388475, 0.004050054477291357, 0.004050054477291357, 0.0013500181590971184, 0.0013500181590971184]
+[0.0, 0.885539991703679, 0.0707283423961354, 0.033676789424087604, 0.0033516254920325675, 0.002513719119024426, 0.002513719119024426, 8.379063730081418E-4, 8.379063730081418E-4]
+[0.0, 0.941274614912587, 0.039493554221797074, 0.013617351636368043, 0.0018714930764159698, 0.0014036198073119788, 0.0014036198073119788, 4.6787326910399234E-4, 4.6787326910399234E-4]
+[0.0, 0.8629164357689288, 0.08240433161617239, 0.042964475172183894, 0.0039049191475715927, 0.002928689360678695, 0.002928689360678695, 9.76229786892898E-4, 9.76229786892898E-4]
+[0.0, 0.7346572582355281, 0.14811493088577013, 0.09617150892295925, 0.007018767318580818, 0.005264075488935615, 0.005264075488935615, 0.0017546918296452044, 0.0017546918296452044]
+[0.0, 0.652516683843928, 0.19325594330365106, 0.1267537382052709, 0.009157878215716665, 0.0068684086617875, 0.0068684086617875, 0.0022894695539291657, 0.0022894695539291657]
+[0.0, 0.8453312910406233, 0.0911921228063858, 0.05051253950142603, 0.004321348883854903, 0.003241011662891178, 0.003241011662891178, 0.0010803372209637256, 0.0010803372209637256]
+[0.0, 0.8391115445723726, 0.09423216462400541, 0.053260065990901675, 0.004465408270906731, 0.0033490562031800487, 0.0033490562031800487, 0.0011163520677266825, 0.0011163520677266825]
+[0.0, 0.9110746600799746, 0.05685672768836799, 0.023985751042294938, 0.0026942870631208294, 0.0020207152973406237, 0.0020207152973406237, 6.735717657802072E-4, 6.735717657802072E-4]
+[0.0, 0.8784774929098204, 0.07439306239158176, 0.03655358461641853, 0.0035252866940597024, 0.002643965020544777, 0.002643965020544777, 8.813216735149254E-4, 8.813216735149254E-4]
+[0.0, 0.899170411184316, 0.06340114215141325, 0.028415218993735492, 0.0030044092235119047, 0.002253306917633929, 0.002253306917633929, 7.511023058779761E-4, 7.511023058779761E-4]
+[0.0, 0.714345447820872, 0.15592912744383775, 0.10755824164633454, 0.007389061029651921, 0.0055417957722389425, 0.0055417957722389425, 0.00184726525741298, 0.00184726525741298]
+[0.0, 0.7044880542336174, 0.16008170140415784, 0.11267272341415421, 0.007585840316023546, 0.005689380237017661, 0.005689380237017661, 0.0018964600790058862, 0.0018964600790058862]
+[0.0, 0.9145665721918712, 0.054919891129613575, 0.022706019879999883, 0.0026025055995052403, 0.0019518791996289303, 0.0019518791996289303, 6.5062639987631E-4, 6.5062639987631E-4]
+[0.0, 0.7308791120334182, 0.15172904602295018, 0.09582175046527867, 0.007190030492784309, 0.005392522869588233, 0.005392522869588233, 0.001797507623196077, 0.001797507623196077]
+[0.0, 0.8784774929098204, 0.07439306239158176, 0.03655358461641853, 0.0035252866940597024, 0.002643965020544777, 0.002643965020544777, 8.813216735149254E-4, 8.813216735149254E-4]
+[0.0, 0.8978839346670174, 0.06448229213561388, 0.02846684717656788, 0.00305564200693361, 0.0022917315052002076, 0.0022917315052002076, 7.639105017334024E-4, 7.639105017334024E-4]
+[0.0, 0.901961060233644, 0.061908321182838774, 0.02732961319801486, 0.0029336684618340467, 0.002200251346375535, 0.002200251346375535, 7.334171154585114E-4, 7.334171154585114E-4]
+[0.0, 0.8785925291179076, 0.074322657784752, 0.03651896186876986, 0.0035219504095235056, 0.00264146280714263, 0.00264146280714263, 8.804876023808762E-4, 8.804876023808762E-4]
+[0.0, 0.8453145375026765, 0.09120199782943202, 0.05051801416415702, 0.00432181683457812, 0.003241362625933591, 0.003241362625933591, 0.00108045420864453, 0.00108045420864453]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8786582219493314, 0.07428245236568681, 0.03649919013570855, 0.0035200451830910496, 0.002640033887318288, 0.002640033887318288, 8.800112957727624E-4, 8.800112957727624E-4]
+[0.0, 0.8680877542759771, 0.07979512317368988, 0.04077329517187223, 0.003781275792820374, 0.0028359568446152815, 0.0028359568446152815, 9.453189482050934E-4, 9.453189482050934E-4]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8421853298122527, 0.096603744133428, 0.04747755296111288, 0.004577791031068759, 0.00343334327330157, 0.00343334327330157, 0.0011444477577671895, 0.0011444477577671895]
+[0.0, 0.4280340798679199, 0.29196611888630714, 0.2384933391804628, 0.013835487355103454, 0.010376615516327592, 0.010376615516327592, 0.003458871838775863, 0.003458871838775863]
+[0.0, 0.35819580536789214, 0.31093467030450317, 0.2866664567010862, 0.014734355875506247, 0.011050766906629686, 0.011050766906629686, 0.003683588968876561, 0.003683588968876561]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.5004083417638341, 0.25179648256133014, 0.21199930596407598, 0.011931956570253237, 0.00894896742768993, 0.00894896742768993, 0.002982989142563309, 0.002982989142563309]
+[0.0, 0.67380708023241, 0.17737233699210542, 0.12360499199090756, 0.008405196928192322, 0.006303897696144242, 0.006303897696144242, 0.00210129923204808, 0.00210129923204808]
+[0.0, 0.7529116602594818, 0.150041539249485, 0.07571660820422, 0.007110064095604434, 0.005332548071703327, 0.005332548071703327, 0.0017775160239011083, 0.0017775160239011083]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8784610515009056, 0.07440312488208124, 0.0365585330319328, 0.003525763528360194, 0.002644322646270146, 0.002644322646270146, 8.814408820900485E-4, 8.814408820900485E-4]
+[0.0, 0.8655049267333818, 0.0811033958084805, 0.04186186353886139, 0.0038432713064255747, 0.0028824534798191814, 0.0028824534798191814, 9.608178266063935E-4, 9.608178266063935E-4]
+[0.0, 0.8736116042518245, 0.0773710724521198, 0.03801810360599041, 0.003666406563355185, 0.002749804922516389, 0.002749804922516389, 9.16601640838796E-4, 9.16601640838796E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8569398862012657, 0.08545118653623547, 0.04546102309495016, 0.004049301389182929, 0.0030369760418871975, 0.0030369760418871975, 0.0010123253472957322, 0.0010123253472957322]
+[0.0, 0.7837040679476788, 0.12668426143886025, 0.07160199362853865, 0.006003225661640879, 0.0045024192462306606, 0.0045024192462306606, 0.0015008064154102196, 0.0015008064154102196]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8035351337261281, 0.11234624323910526, 0.0681472661493474, 0.005323785628473193, 0.003992839221354896, 0.003992839221354896, 0.001330946407118298, 0.001330946407118298]
+[0.0, 0.7709798475664911, 0.1324437622790968, 0.07774793151067144, 0.006276152881246899, 0.004707114660935176, 0.004707114660935176, 0.0015690382203117246, 0.0015690382203117246]
+[0.0, 0.9029147223953891, 0.061392196236519835, 0.02696544929243424, 0.0029092106918856444, 0.002181908018914234, 0.002181908018914234, 7.27302672971411E-4, 7.27302672971411E-4]
+[0.0, 0.6904609518143073, 0.17777853492292706, 0.10648717660318453, 0.008424445553193705, 0.006318334164895281, 0.006318334164895281, 0.002106111388298426, 0.002106111388298426]
+[0.0, 0.8971731965075, 0.06447281080701894, 0.029188414548493097, 0.003055192712329205, 0.002291394534246904, 0.002291394534246904, 7.637981780823012E-4, 7.637981780823012E-4]
+[2.0, 0.06359384734476137, 0.32631225833306227, 0.563704719360334, 0.015463058320614158, 0.011597293740460621, 0.011597293740460621, 0.003865764580153539, 0.003865764580153539]
+[2.0, 0.05217365212491938, 0.3143879495177992, 0.5887444059508112, 0.014897997468823462, 0.011173498101617598, 0.011173498101617598, 0.0037244993672058647, 0.0037244993672058647]
+[2.0, 0.06677858796226017, 0.32915952692749745, 0.5572679369974761, 0.015597982704255504, 0.011698487028191632, 0.011698487028191632, 0.0038994956760638757, 0.0038994956760638757]
+[2.0, 0.04618171025469615, 0.33440008714621033, 0.5718792464191286, 0.015846318726655057, 0.011884739044991295, 0.011884739044991295, 0.003961579681663763, 0.003961579681663763]
+[2.0, 0.05357988385347444, 0.34391479911162937, 0.5536137311978964, 0.016297195279000053, 0.012222896459250041, 0.012222896459250041, 0.004074298819750012, 0.004074298819750012]
+[2.0, 0.07182186103009258, 0.33331297163958473, 0.5474807575707045, 0.015794803253206192, 0.011846102439904646, 0.011846102439904646, 0.003948700813301548, 0.003948700813301548]
+[0.0, 0.7712555033980293, 0.1354129154750714, 0.07408102198408378, 0.006416853047605134, 0.004812639785703852, 0.004812639785703852, 0.0016042132619012834, 0.0016042132619012834]
+[0.0, 0.7152204302463994, 0.17022788922455617, 0.09035175810822313, 0.008066640806940403, 0.006049980605205304, 0.006049980605205304, 0.0020166602017351004, 0.0020166602017351004]
+[0.0, 0.9210504386472592, 0.05129078354911606, 0.020367181882145532, 0.002430531973826311, 0.0018228989803697336, 0.0018228989803697336, 6.076329934565776E-4, 6.076329934565776E-4]
+[0.0, 0.882884120103691, 0.07215423612505349, 0.034704059514562145, 0.003419194752231044, 0.002564396064173283, 0.002564396064173283, 8.547986880577609E-4, 8.547986880577609E-4]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.849720165087594, 0.08918585451305039, 0.048415148686866014, 0.004226277237496528, 0.003169707928122396, 0.003169707928122396, 0.0010565693093741318, 0.0010565693093741318]
+[0.0, 0.6509350053252865, 0.18999870015447348, 0.1320557157911005, 0.009003526243046532, 0.006752644682284901, 0.006752644682284901, 0.002250881560761633, 0.002250881560761633]
+[0.0, 0.60037635853223, 0.2099701191283708, 0.15980376847859548, 0.009949917953601234, 0.007462438465200927, 0.007462438465200927, 0.002487479488400308, 0.002487479488400308]
+[0.0, 0.8483624648232375, 0.08969893361395204, 0.04918682954368755, 0.004250590673040933, 0.0031879430047807005, 0.0031879430047807005, 0.001062647668260233, 0.001062647668260233]
+[0.0, 0.8126335146453953, 0.11263043539566227, 0.058724291772816004, 0.005337252728708872, 0.004002939546531655, 0.004002939546531655, 0.0013343131821772177, 0.0013343131821772177]
+[0.0, 0.7876470914783803, 0.12478939837301754, 0.06982321052246841, 0.005913433208711339, 0.004435074906533506, 0.004435074906533506, 0.0014783583021778346, 0.0014783583021778346]
+[0.0, 0.7583851069428539, 0.1382278900452117, 0.08373626169847523, 0.0065502471044863704, 0.004912685328364779, 0.004912685328364779, 0.0016375617761215924, 0.0016375617761215924]
+[0.0, 0.7583851069428539, 0.1382278900452117, 0.08373626169847523, 0.0065502471044863704, 0.004912685328364779, 0.004912685328364779, 0.0016375617761215924, 0.0016375617761215924]
+[0.0, 0.7548779488139653, 0.13931046388479365, 0.08600694521951156, 0.006601547360576478, 0.004951160520432359, 0.004951160520432359, 0.0016503868401441192, 0.0016503868401441192]
+[0.0, 0.660516478090187, 0.19019165793639242, 0.1222538539968265, 0.009012669992197946, 0.006759502494148461, 0.006759502494148461, 0.002253167498049486, 0.002253167498049486]
+[0.0, 0.8499919787046132, 0.08902458746737107, 0.048327528147283985, 0.004218635226910498, 0.0031639764201828744, 0.0031639764201828744, 0.0010546588067276244, 0.0010546588067276244]
+[0.0, 0.861770721998618, 0.0829616278637504, 0.04347366639411343, 0.003931327914505999, 0.0029484959358794995, 0.0029484959358794995, 9.828319786264995E-4, 9.828319786264995E-4]
+[0.0, 0.663847641668853, 0.18574695148494955, 0.12399926484257914, 0.008802047334539402, 0.006601535500904553, 0.006601535500904553, 0.00220051183363485, 0.00220051183363485]
+[0.0, 0.7552394078381451, 0.13811930567253014, 0.08700598173803523, 0.006545101583763186, 0.00490882618782239, 0.00490882618782239, 0.0016362753959407962, 0.0016362753959407962]
+[0.0, 0.8542092553012622, 0.08680262370665658, 0.04664809393074704, 0.004113342353778072, 0.003085006765333554, 0.003085006765333554, 0.0010283355884445177, 0.0010283355884445177]
+[0.0, 0.7630384792703983, 0.1425542831664313, 0.07414144792612322, 0.006755263212349041, 0.005066447409261782, 0.005066447409261782, 0.00168881580308726, 0.00168881580308726]
+[0.0, 0.8336311191424218, 0.1018468541730228, 0.05004328303673525, 0.0048262478826066515, 0.003619685911954992, 0.003619685911954992, 0.0012065619706516627, 0.0012065619706516627]
+[0.0, 0.8658571231589782, 0.08089106987921524, 0.04175217770286682, 0.0038332097529798683, 0.0028749073147349017, 0.0028749073147349017, 9.58302438244967E-4, 9.58302438244967E-4]
+[0.0, 0.8787184353451832, 0.07424560047301072, 0.03648106756810295, 0.003518298871234468, 0.0026387241534258513, 0.0026387241534258513, 8.795747178086167E-4, 8.795747178086167E-4]
+[0.0, 0.8125049924514746, 0.10796508825448457, 0.0641813957834839, 0.005116174503519096, 0.0038371308776393226, 0.0038371308776393226, 0.0012790436258797737, 0.0012790436258797737]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8713470175104103, 0.07806580843291644, 0.039489189370373406, 0.003699328228766608, 0.0027744961715749565, 0.0027744961715749565, 9.248320571916519E-4, 9.248320571916519E-4]
+[0.0, 0.8421853298122527, 0.096603744133428, 0.04747755296111288, 0.004577791031068759, 0.00343334327330157, 0.00343334327330157, 0.0011444477577671895, 0.0011444477577671895]
+[0.0, 0.7925313923232735, 0.12232294131797197, 0.06775600298651702, 0.005796554457412539, 0.004347415843059406, 0.004347415843059406, 0.0014491386143531345, 0.0014491386143531345]
+[0.0, 0.8204454718704786, 0.10861444054713164, 0.05549925090753635, 0.005146945558284612, 0.0038602091687134597, 0.0038602091687134597, 0.0012867363895711528, 0.0012867363895711528]
+[0.0, 0.8099446719212194, 0.11388508139400477, 0.05998012562307252, 0.0053967070205678475, 0.004047530265425887, 0.004047530265425887, 0.0013491767551419617, 0.0013491767551419617]
+[0.0, 0.8053347233462269, 0.11627529573483883, 0.061860062413458365, 0.005509972835158731, 0.00413247962636905, 0.00413247962636905, 0.0013774932087896826, 0.0013774932087896826]
+[0.0, 0.8732962795313527, 0.07712046482026055, 0.038619662818741234, 0.0036545309432150586, 0.0027408982074112946, 0.0027408982074112946, 9.136327358037644E-4, 9.136327358037644E-4]
+[0.0, 0.8273072720519045, 0.10511250672255916, 0.05263722616326178, 0.004980998354091552, 0.0037357487655686646, 0.0037357487655686646, 0.001245249588522888, 0.001245249588522888]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.7168919678001965, 0.15788796320330223, 0.10277441406823579, 0.00748188497608849, 0.005611413732066369, 0.005611413732066369, 0.0018704712440221222, 0.0018704712440221222]
+[0.0, 0.6547655883805463, 0.19200570607820883, 0.12593280701008122, 0.009098632843721218, 0.006823974632790916, 0.006823974632790916, 0.002274658210930304, 0.002274658210930304]
+[0.0, 0.9075769921046121, 0.05877007508563214, 0.025298066493684938, 0.0027849554386903826, 0.0020887165790177873, 0.0020887165790177873, 6.962388596725954E-4, 6.962388596725954E-4]
+[0.0, 0.8629849077399082, 0.08339498116020203, 0.041764521022634477, 0.003951863359085045, 0.002963897519313784, 0.002963897519313784, 9.87965839771261E-4, 9.87965839771261E-4]
+[0.0, 0.8238371780318979, 0.10689433466419485, 0.054072184172365895, 0.0050654343771804845, 0.0037990757828853645, 0.0037990757828853645, 0.001266358594295121, 0.001266358594295121]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.833203508473273, 0.10210855719972703, 0.050171986476199956, 0.004838649283599924, 0.003628986962699944, 0.003628986962699944, 0.0012096623208999807, 0.0012096623208999807]
+[0.0, 0.9050079557039731, 0.060236447022337325, 0.026192268717558937, 0.0028544428520435173, 0.0021408321390326383, 0.0021408321390326383, 7.136107130108791E-4, 7.136107130108791E-4]
+[0.0, 0.8780411476002429, 0.07466011483115487, 0.0366849128006754, 0.003537941589309046, 0.002653456191981785, 0.002653456191981785, 8.844853973272613E-4, 8.844853973272613E-4]
+[0.0, 0.8787678321468105, 0.07424208072239682, 0.036435690891570845, 0.0035181320797406553, 0.002638599059805492, 0.002638599059805492, 8.795330199351636E-4, 8.795330199351636E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.6868590127144314, 0.17733922009040454, 0.11059088437269385, 0.008403627607490076, 0.006302720705617559, 0.006302720705617559, 0.0021009069018725185, 0.0021009069018725185]
+[0.0, 0.67658610502807, 0.18184834731441873, 0.11571363868178365, 0.008617302991909234, 0.006462977243931927, 0.006462977243931927, 0.002154325747977308, 0.002154325747977308]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.875836038241761, 0.07580647357400215, 0.037580694864154864, 0.0035922644400273895, 0.0026941983300205422, 0.0026941983300205422, 8.980661100068472E-4, 8.980661100068472E-4]
+[0.0, 0.8542540518129135, 0.08677595956569115, 0.046633752185355926, 0.004112078812013124, 0.0030840591090098434, 0.0030840591090098434, 0.0010280197030032808, 0.0010280197030032808]
+[0.0, 0.8785925291179076, 0.074322657784752, 0.03651896186876986, 0.0035219504095235056, 0.00264146280714263, 0.00264146280714263, 8.804876023808762E-4, 8.804876023808762E-4]
+[0.0, 0.8512801022525969, 0.08826034233553497, 0.04791229628127099, 0.004182419710199001, 0.0031368147826492513, 0.0031368147826492513, 0.00104560492754975, 0.00104560492754975]
+[0.0, 0.9160423976312199, 0.05411546885414584, 0.022148974925860425, 0.0025643861962578673, 0.0019232896471934006, 0.0019232896471934006, 6.410965490644667E-4, 6.410965490644667E-4]
+[0.0, 0.7145653844696164, 0.15580911795008767, 0.10747537527057975, 0.007383374103238661, 0.0055375305774289976, 0.0055375305774289976, 0.001845843525809665, 0.001845843525809665]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8778926482295029, 0.07475099948392114, 0.036729607182526366, 0.0035422483680165105, 0.0026566862760123836, 0.0026566862760123836, 8.855620920041274E-4, 8.855620920041274E-4]
+[0.0, 0.8887110522538724, 0.06897262580671108, 0.032511041492797675, 0.003268426815539614, 0.002451320111654711, 0.002451320111654711, 8.171067038849033E-4, 8.171067038849033E-4]
+[0.0, 0.8681612399776832, 0.07975068251318956, 0.0407505678999886, 0.003779169869712755, 0.0028343774022845667, 0.0028343774022845667, 9.447924674281886E-4, 9.447924674281886E-4]
+[0.0, 0.8571317501913073, 0.08533661551795824, 0.04540001775834697, 0.004043872177462469, 0.0030329041330968516, 0.0030329041330968516, 0.001010968044365617, 0.001010968044365617]
+[0.0, 0.8850656113706346, 0.07102140480791683, 0.033816445032190445, 0.0033655129297528235, 0.002524134697314618, 0.002524134697314618, 8.413782324382059E-4, 8.413782324382059E-4]
+[0.0, 0.8808559424121896, 0.07318400574401975, 0.03555607356785765, 0.0034679927586443327, 0.0026009945689832504, 0.0026009945689832504, 8.669981896610831E-4, 8.669981896610831E-4]
+[0.0, 0.8758639030989697, 0.07578946541521048, 0.03757225607813247, 0.003591458469229156, 0.0026935938519218675, 0.0026935938519218675, 8.978646173072888E-4, 8.978646173072888E-4]
+[0.0, 0.6410595263062674, 0.1861138546381159, 0.14636831739776662, 0.008819433885950037, 0.0066145754144625295, 0.0066145754144625295, 0.0022048584714875093, 0.0022048584714875093]
+[0.0, 0.5356255393019027, 0.23780330445701026, 0.19276458350209763, 0.011268857579663106, 0.008451643184747332, 0.008451643184747332, 0.0028172143949157765, 0.0028172143949157765]
+[0.0, 0.9213528578635178, 0.050827609283374764, 0.02059378267141499, 0.0024085833938975276, 0.0018064375454231443, 0.0018064375454231443, 6.021458484743818E-4, 6.021458484743818E-4]
+[0.0, 0.8856153946888523, 0.07068175995210409, 0.033654591132313096, 0.00334941807557677, 0.0025120635566825773, 0.0025120635566825773, 8.373545188941923E-4, 8.373545188941923E-4]
+[0.0, 0.8544216520664651, 0.08611569411664353, 0.0472202819803421, 0.004080790612183103, 0.0030605929591373273, 0.0030605929591373273, 0.0010201976530457755, 0.0010201976530457755]
+[0.0, 0.8209505343285004, 0.10864544515526059, 0.05495877616697428, 0.005148414783088347, 0.003861311087316261, 0.003861311087316261, 0.0012871036957720866, 0.0012871036957720866]
+[0.0, 0.7544314116039524, 0.1404890318166113, 0.08510736702562345, 0.0066573965179375855, 0.00499304738845319, 0.00499304738845319, 0.001664349129484396, 0.001664349129484396]
+[0.0, 0.680893892514398, 0.18255961961681128, 0.11059346306171258, 0.00865100826902606, 0.006488256201769546, 0.006488256201769546, 0.0021627520672565146, 0.0021627520672565146]
+[0.0, 0.7544314116039524, 0.1404890318166113, 0.08510736702562345, 0.0066573965179375855, 0.00499304738845319, 0.00499304738845319, 0.001664349129484396, 0.001664349129484396]
+[0.0, 0.680893892514398, 0.18255961961681128, 0.11059346306171258, 0.00865100826902606, 0.006488256201769546, 0.006488256201769546, 0.0021627520672565146, 0.0021627520672565146]
+[0.0, 0.8598850852437406, 0.08395975686803717, 0.04421927821578342, 0.003978626557479534, 0.0029839699181096503, 0.0029839699181096503, 9.946566393698832E-4, 9.946566393698832E-4]
+[0.0, 0.883207493149139, 0.07195505740408621, 0.03460818081813336, 0.003409756209547188, 0.0025573171571603914, 0.0025573171571603914, 8.524390523867968E-4, 8.524390523867968E-4]
+[0.0, 0.8707386580479559, 0.07843486128469304, 0.03967603072155214, 0.003716816648599694, 0.002787612486449771, 0.002787612486449771, 9.292041621499233E-4, 9.292041621499233E-4]
+[0.0, 0.6474022832637669, 0.19465482070636783, 0.1302703942947414, 0.00922416724504121, 0.0069181254337809086, 0.0069181254337809086, 0.002306041811260302, 0.002306041811260302]
+[0.0, 0.6528167299864552, 0.19237900186771262, 0.12745530117102422, 0.009116322324936005, 0.0068372417437020045, 0.0068372417437020045, 0.0022790805812340008, 0.0022790805812340008]
+[0.0, 0.8831624977108254, 0.07198277194912556, 0.03462152175865993, 0.0034110695271297423, 0.0025583021453473073, 0.0025583021453473073, 8.527673817824355E-4, 8.527673817824355E-4]
+[0.0, 0.8427791057700864, 0.0923910988420359, 0.0516953000091427, 0.0043781651262448954, 0.003283623844683672, 0.003283623844683672, 0.0010945412815612236, 0.0010945412815612236]
+[0.0, 0.8537644305828744, 0.0870673957199992, 0.046790506139800146, 0.004125889185775428, 0.0030944168893315715, 0.0030944168893315715, 0.0010314722964438567, 0.0010314722964438567]
+[0.0, 0.8783296860074628, 0.07451033206313193, 0.03656745056635226, 0.0035308437876843267, 0.0026481328407632456, 0.0026481328407632456, 8.827109469210816E-4, 8.827109469210816E-4]
+[0.0, 0.8542540518129135, 0.08677595956569115, 0.046633752185355926, 0.004112078812013124, 0.0030840591090098434, 0.0030840591090098434, 0.0010280197030032808, 0.0010280197030032808]
+[0.0, 0.8855659631793777, 0.07071229774301835, 0.03366914354009032, 0.0033508651791710454, 0.0025131488843782844, 0.0025131488843782844, 8.377162947927611E-4, 8.377162947927611E-4]
+[0.0, 0.8573390720032374, 0.08521281385174273, 0.045334097494365476, 0.004038005550218188, 0.0030285041626636412, 0.0030285041626636412, 0.0010095013875545467, 0.0010095013875545467]
+[0.0, 0.7250386311621279, 0.1544641263139721, 0.09853832679848065, 0.00731963857513979, 0.005489728931354843, 0.005489728931354843, 0.0018299096437849472, 0.0018299096437849472]
+[0.0, 0.8956618389692291, 0.06560679714494255, 0.029404576081441293, 0.0031089292681290635, 0.002331696951096798, 0.002331696951096798, 7.772323170322657E-4, 7.772323170322657E-4]
+[0.0, 0.8784747308870676, 0.07439475280803605, 0.03655441590988014, 0.003525366798338812, 0.002644025098754109, 0.002644025098754109, 8.813416995847028E-4, 8.813416995847028E-4]
+[0.0, 0.8472889318192396, 0.0901861382207994, 0.04970389600178378, 0.004273677986058957, 0.003205258489544218, 0.003205258489544218, 0.001068419496514739, 0.001068419496514739]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8784610515009056, 0.07440312488208124, 0.0365585330319328, 0.003525763528360194, 0.002644322646270146, 0.002644322646270146, 8.814408820900485E-4, 8.814408820900485E-4]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8890371459609124, 0.06887161307677683, 0.032300320678642205, 0.0032636400945562317, 0.002447730070917174, 0.002447730070917174, 8.159100236390577E-4, 8.159100236390577E-4]
+[0.0, 0.9086603346925847, 0.058241065145242, 0.02481893891135675, 0.0027598870836055183, 0.002069915312704139, 0.002069915312704139, 6.899717709013795E-4, 6.899717709013795E-4]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.7645528692915217, 0.13470047748266759, 0.08159737563106806, 0.006383092531580888, 0.004787319398685667, 0.004787319398685667, 0.0015957731328952217, 0.0015957731328952217]
+[0.0, 0.6928121660718066, 0.17574369151360403, 0.10646008298724335, 0.008328019809115272, 0.006246014856836456, 0.006246014856836456, 0.002082004952278818, 0.002082004952278818]
+[0.0, 0.7719059345577957, 0.13049512421141413, 0.07904750470298469, 0.006183812175935147, 0.0046378591319513615, 0.0046378591319513615, 0.0015459530439837865, 0.0015459530439837865]
+[0.0, 0.7719059345577957, 0.13049512421141413, 0.07904750470298469, 0.006183812175935147, 0.0046378591319513615, 0.0046378591319513615, 0.0015459530439837865, 0.0015459530439837865]
+[0.0, 0.8781400607647344, 0.07459957793339733, 0.036655142575148916, 0.0035350729089065496, 0.0026513046816799123, 0.0026513046816799123, 8.837682272266372E-4, 8.837682272266372E-4]
+[0.0, 0.47322811591215536, 0.270039279591997, 0.21834330385616124, 0.01279643354656224, 0.009597325159921682, 0.009597325159921682, 0.0031991083866405594, 0.0031991083866405594]
+[0.0, 0.5876348834933671, 0.21491323499852427, 0.16689940483778304, 0.010184158890108498, 0.0076381191675813755, 0.0076381191675813755, 0.002546039722527124, 0.002546039722527124]
+[0.0, 0.7143415346485599, 0.16047115807414655, 0.10237442042388886, 0.007604295617801516, 0.005703221713351139, 0.005703221713351139, 0.0019010739044503788, 0.0019010739044503788]
+[0.0, 0.39357970261241015, 0.29280547092751547, 0.27198904050269496, 0.013875261985793188, 0.010406446489344894, 0.010406446489344894, 0.0034688154964482966, 0.0034688154964482966]
+[0.0, 0.6626111516530299, 0.19038543250131545, 0.11993785850617186, 0.009021852446494219, 0.006766389334870665, 0.006766389334870665, 0.0022554631116235542, 0.0022554631116235542]
+[0.0, 0.5340162271211221, 0.23862695265524445, 0.19343315608093756, 0.011307888047565311, 0.008480916035673984, 0.008480916035673984, 0.0028269720118913274, 0.0028269720118913274]
+[0.0, 0.7184139805372294, 0.1542911026711029, 0.10536059843835632, 0.007311439451103815, 0.005483579588327863, 0.005483579588327863, 0.0018278598627759536, 0.0018278598627759536]
+[0.0, 0.8486601449220934, 0.09434434285103331, 0.043583339942773504, 0.004470724094699857, 0.0033530430710248934, 0.0033530430710248934, 0.001117681023674964, 0.001117681023674964]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8658720046521987, 0.08088209838499885, 0.041747543108645674, 0.0038327846180523624, 0.0028745884635392725, 0.0028745884635392725, 9.581961545130905E-4, 9.581961545130905E-4]
+[0.0, 0.8784774929098204, 0.07439306239158176, 0.03655358461641853, 0.0035252866940597024, 0.002643965020544777, 0.002643965020544777, 8.813216735149254E-4, 8.813216735149254E-4]
+[0.0, 0.8535980103890273, 0.09153094058888081, 0.04185883538632427, 0.004337404545255873, 0.003253053408941905, 0.003253053408941905, 0.001084351136313968, 0.001084351136313968]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8421853298122527, 0.096603744133428, 0.04747755296111288, 0.004577791031068759, 0.00343334327330157, 0.00343334327330157, 0.0011444477577671895, 0.0011444477577671895]
+[0.0, 0.8421853298122527, 0.096603744133428, 0.04747755296111288, 0.004577791031068759, 0.00343334327330157, 0.00343334327330157, 0.0011444477577671895, 0.0011444477577671895]
+[0.0, 0.8069832144508512, 0.11529092129961198, 0.06133588629712807, 0.005463325984136365, 0.004097494488102275, 0.004097494488102275, 0.001365831496034091, 0.001365831496034091]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8298651611659844, 0.10290937824896715, 0.05259566648171741, 0.004876598034443776, 0.0036574485258328323, 0.0036574485258328323, 0.0012191495086109438, 0.0012191495086109438]
+[0.0, 0.8747686689454263, 0.07645797389108692, 0.03790394531184436, 0.0036231372838808336, 0.002717352962910626, 0.002717352962910626, 9.057843209702084E-4, 9.057843209702084E-4]
+[0.0, 0.8759169386642255, 0.07575709355003407, 0.03755619442434196, 0.0035899244537994967, 0.002692443340349623, 0.002692443340349623, 8.974811134498741E-4, 8.974811134498741E-4]
+[0.0, 0.857147440032024, 0.08532724637348199, 0.0453950289976111, 0.004043428198961045, 0.0030325711492207837, 0.0030325711492207837, 0.001010857049740261, 0.001010857049740261]
+[0.0, 0.8575617948580357, 0.08507981543021606, 0.04526328037115735, 0.004031703113530326, 0.0030237773351477447, 0.0030237773351477447, 0.0010079257783825813, 0.0010079257783825813]
+[0.0, 0.3936928364688133, 0.29391517860119826, 0.27060844080656904, 0.013927848041139829, 0.010445886030854874, 0.010445886030854874, 0.003481962010284957, 0.003481962010284957]
+[1.0, 0.31081304355814365, 0.33409222185745335, 0.30759954512291127, 0.015831729820497315, 0.011873797365372989, 0.011873797365372989, 0.003957932455124329, 0.003957932455124329]
+[1.0, 0.31081304355814365, 0.33409222185745335, 0.30759954512291127, 0.015831729820497315, 0.011873797365372989, 0.011873797365372989, 0.003957932455124329, 0.003957932455124329]
+[1.0, 0.31081304355814365, 0.33409222185745335, 0.30759954512291127, 0.015831729820497315, 0.011873797365372989, 0.011873797365372989, 0.003957932455124329, 0.003957932455124329]
+[0.0, 0.8177556489163615, 0.11156269776690884, 0.0548216867547568, 0.005286655520657691, 0.00396499164049327, 0.00396499164049327, 0.0013216638801644225, 0.0013216638801644225]
+[0.0, 0.8831624977108254, 0.07198277194912556, 0.03462152175865993, 0.0034110695271297423, 0.0025583021453473073, 0.0025583021453473073, 8.527673817824355E-4, 8.527673817824355E-4]
+[0.0, 0.8898800491788488, 0.06834857136892285, 0.03205481577845791, 0.003238854557923388, 0.002429140918442543, 0.002429140918442543, 8.097136394808468E-4, 8.097136394808468E-4]
+[0.0, 0.691439365638592, 0.17652878795579866, 0.10693617616595472, 0.00836522341321822, 0.006273917559913667, 0.006273917559913667, 0.002091305853304555, 0.002091305853304555]
+[0.0, 0.7633911804045264, 0.13536486347094825, 0.08200022814655167, 0.006414575992657907, 0.004810931994493431, 0.004810931994493431, 0.0016036439981644765, 0.0016036439981644765]
+[0.0, 0.8969407245157738, 0.06424754398103324, 0.02967817772917919, 0.0030445179246711782, 0.002283388443503384, 0.002283388443503384, 7.611294811677946E-4, 7.611294811677946E-4]
+[0.0, 0.88931948045691, 0.06959385640021765, 0.031193067366510556, 0.003297865258787238, 0.002473398944090429, 0.002473398944090429, 8.244663146968093E-4, 8.244663146968093E-4]
+[0.0, 0.8614892802717213, 0.08326199991548414, 0.04341203460371523, 0.0039455617363598535, 0.002959171302269891, 0.002959171302269891, 9.863904340899634E-4, 9.863904340899634E-4]
+[0.0, 0.8171378322515124, 0.11026977950554286, 0.05691622541468453, 0.005225387609420097, 0.0039190407070650735, 0.0039190407070650735, 0.001306346902355024, 0.001306346902355024]
+[0.0, 0.8762673974819931, 0.07911158100659879, 0.03337436779520807, 0.0037488845720666, 0.002811663429049951, 0.002811663429049951, 9.372211430166499E-4, 9.372211430166499E-4]
+[0.0, 0.7883379797255579, 0.12365756087742584, 0.070425063954745, 0.005859798480757207, 0.004394848860567907, 0.004394848860567907, 0.0014649496201893015, 0.0014649496201893015]
+[0.0, 0.6919714654463609, 0.1762975639487221, 0.1066681716124978, 0.008354266330806374, 0.0062656997481047826, 0.0062656997481047826, 0.002088566582701593, 0.002088566582701593]
+[0.0, 0.7278714887984878, 0.15023153104001705, 0.10053977827823792, 0.0071190672944191, 0.005339300470814327, 0.005339300470814327, 0.0017797668236047748, 0.0017797668236047748]
+[0.0, 0.8780466226017747, 0.07465676401760779, 0.036683264970755025, 0.003537782803287445, 0.0026533371024655846, 0.0026533371024655846, 8.844457008218611E-4, 8.844457008218611E-4]
+[0.0, 0.8363124221302781, 0.09962466594767225, 0.04990007880394924, 0.004720944372700187, 0.0035407082795251405, 0.0035407082795251405, 0.0011802360931750465, 0.0011802360931750465]
+[0.0, 0.8782636050554478, 0.07452396625833617, 0.03661795905988694, 0.0035314898754429517, 0.0026486174065822148, 0.0026486174065822148, 8.828724688607379E-4, 8.828724688607379E-4]
+[0.0, 0.7632298527764134, 0.1355133031900196, 0.08199201358112747, 0.006421610150813108, 0.004816207613109832, 0.004816207613109832, 0.0016054025377032768, 0.0016054025377032768]
+[0.0, 0.6707219506911802, 0.1858103540239521, 0.11705253985499989, 0.008805051809955925, 0.006603788857466945, 0.006603788857466945, 0.0022012629524889808, 0.0022012629524889808]
+[0.0, 0.8780466226017747, 0.07465676401760779, 0.036683264970755025, 0.003537782803287445, 0.0026533371024655846, 0.0026533371024655846, 8.844457008218611E-4, 8.844457008218611E-4]
+[0.0, 0.8532177954094134, 0.087251862262027, 0.047126450654687825, 0.004134630557957244, 0.0031009729184679332, 0.0031009729184679332, 0.0010336576394893108, 0.0010336576394893108]
+[0.0, 0.8701771979205339, 0.07877546284503133, 0.039848468719161555, 0.003732956838424335, 0.002799717628818252, 0.002799717628818252, 9.332392096060838E-4, 9.332392096060838E-4]
+[0.0, 0.921495332461208, 0.0510018108054097, 0.02025234173002594, 0.0024168383344520938, 0.0018126287508390705, 0.0018126287508390705, 6.042095836130233E-4, 6.042095836130233E-4]
+[0.0, 0.8100117995055802, 0.11384486866900378, 0.05995892748163587, 0.00539480144792679, 0.004046101085945094, 0.004046101085945094, 0.0013487003619816972, 0.0013487003619816972]
+[0.0, 0.8833821209567272, 0.07184749691149389, 0.034556404508554774, 0.003404659207741478, 0.0025534944058061087, 0.0025534944058061087, 8.511648019353693E-4, 8.511648019353693E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8782636050554478, 0.07452396625833617, 0.03661795905988694, 0.0035314898754429517, 0.0026486174065822148, 0.0026486174065822148, 8.828724688607379E-4, 8.828724688607379E-4]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8632136895665046, 0.08222569259983269, 0.042871256055292364, 0.003896453926123557, 0.0029223404445926685, 0.0029223404445926685, 9.741134815308891E-4, 9.741134815308891E-4]
+[0.0, 0.8576370243311641, 0.08503489231484833, 0.04523936036942666, 0.004029574328187039, 0.00302218074614028, 0.00302218074614028, 0.0010073935820467596, 0.0010073935820467596]
+[0.0, 0.8333496790463713, 0.10201909902230177, 0.05012799162618604, 0.004834410101713689, 0.0036258075762852673, 0.0036258075762852673, 0.0012086025254284222, 0.0012086025254284222]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.8758164760491686, 0.07581841394954396, 0.037586619214573236, 0.0035928302622380433, 0.002694622696678533, 0.002694622696678533, 8.982075655595106E-4, 8.982075655595106E-4]
+[0.0, 0.8784747308870676, 0.07439475280803605, 0.03655441590988014, 0.003525366798338812, 0.002644025098754109, 0.002644025098754109, 8.813416995847028E-4, 8.813416995847028E-4]
+[0.0, 0.8354364332249554, 0.10093057119663122, 0.04928451247159625, 0.004782827702272308, 0.003587120776704232, 0.003587120776704232, 0.001195706925568077, 0.001195706925568077]
+[0.0, 0.8334708680592899, 0.10194492984612322, 0.05009151582143573, 0.004830895424383761, 0.0036231715682878206, 0.0036231715682878206, 0.0012077238560959398, 0.0012077238560959398]
+[0.0, 0.8784747308870676, 0.07439475280803605, 0.03655441590988014, 0.003525366798338812, 0.002644025098754109, 0.002644025098754109, 8.813416995847028E-4, 8.813416995847028E-4]
+[0.0, 0.8901274043373386, 0.06829491702976821, 0.03186874256263153, 0.0032363120234205774, 0.0024272340175654334, 0.0024272340175654334, 8.090780058551442E-4, 8.090780058551442E-4]
+[0.0, 0.885539991703679, 0.0707283423961354, 0.033676789424087604, 0.0033516254920325675, 0.002513719119024426, 0.002513719119024426, 8.379063730081418E-4, 8.379063730081418E-4]
+[0.0, 0.8339085952499695, 0.1016770352433997, 0.04995976764275203, 0.004818200621292842, 0.0036136504659696317, 0.0036136504659696317, 0.0012045501553232102, 0.0012045501553232102]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.4983631535523358, 0.26555847169357555, 0.19832607433815136, 0.01258410013864583, 0.009438075103984374, 0.009438075103984374, 0.003146025034661457, 0.003146025034661457]
+[0.0, 0.4983631535523358, 0.26555847169357555, 0.19832607433815136, 0.01258410013864583, 0.009438075103984374, 0.009438075103984374, 0.003146025034661457, 0.003146025034661457]
+[0.0, 0.5885459994674848, 0.21781712473352358, 0.16267157660806897, 0.010321766396974193, 0.007741324797730646, 0.007741324797730646, 0.0025804415992435477, 0.0025804415992435477]
+[0.0, 0.8334281135819308, 0.10197109611751147, 0.05010438418020344, 0.004832135373451492, 0.00362410153008862, 0.00362410153008862, 0.0012080338433628729, 0.0012080338433628729]
+[0.0, 0.8729298760798572, 0.07778829949661116, 0.03822329093856119, 0.003686177828323486, 0.0027646333712426146, 0.0027646333712426146, 9.215444570808713E-4, 9.215444570808713E-4]
+[0.0, 0.8333496790463713, 0.10201909902230177, 0.05012799162618604, 0.004834410101713689, 0.0036258075762852673, 0.0036258075762852673, 0.0012086025254284222, 0.0012086025254284222]
+[0.0, 0.7793911813048597, 0.12877810760554265, 0.07352336892756628, 0.006102447387343741, 0.0045768355405078065, 0.0045768355405078065, 0.001525611846835935, 0.001525611846835935]
+[0.0, 0.8492122575237256, 0.09372708699722697, 0.04373623346809057, 0.004441474003652385, 0.0033311055027392894, 0.0033311055027392894, 0.001110368500913096, 0.001110368500913096]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.7366369840628725, 0.14754597793591945, 0.09484161948536597, 0.006991806171947318, 0.00524385462896049, 0.00524385462896049, 0.0017479515429868293, 0.0017479515429868293]
+[0.0, 0.6330110861621799, 0.2018415282332948, 0.13645320777739922, 0.009564725942375346, 0.0071735444567815115, 0.0071735444567815115, 0.0023911814855938364, 0.0023911814855938364]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.833203508473273, 0.10210855719972703, 0.050171986476199956, 0.004838649283599924, 0.003628986962699944, 0.003628986962699944, 0.0012096623208999807, 0.0012096623208999807]
+[0.0, 0.833203508473273, 0.10210855719972703, 0.050171986476199956, 0.004838649283599924, 0.003628986962699944, 0.003628986962699944, 0.0012096623208999807, 0.0012096623208999807]
+[0.0, 0.9281504391899726, 0.047218679719440375, 0.0179181832404909, 0.0022375659500320053, 0.001678174462524004, 0.001678174462524004, 5.593914875080012E-4, 5.593914875080012E-4]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8542700039775727, 0.086766464388945, 0.04662864504993585, 0.00411162886118216, 0.0030837216458866204, 0.0030837216458866204, 0.0010279072152955399, 0.0010279072152955399]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.8626642589271379, 0.08255588088281739, 0.04304355821363177, 0.003912100658804267, 0.002934075494103201, 0.002934075494103201, 9.780251647010668E-4, 9.780251647010668E-4]
+[0.0, 0.8541773384938535, 0.08682162148457213, 0.046658312199784086, 0.004114242607263397, 0.0030856819554475486, 0.0030856819554475486, 0.001028560651815849, 0.001028560651815849]
+[0.0, 0.8732962795313527, 0.07712046482026055, 0.038619662818741234, 0.0036545309432150586, 0.0027408982074112946, 0.0027408982074112946, 9.136327358037644E-4, 9.136327358037644E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8333496790463713, 0.10201909902230177, 0.05012799162618604, 0.004834410101713689, 0.0036258075762852673, 0.0036258075762852673, 0.0012086025254284222, 0.0012086025254284222]
+[0.0, 0.8655706690903843, 0.08106376223617467, 0.041841389138632216, 0.003841393178269586, 0.0028810448837021897, 0.0028810448837021897, 9.603482945673963E-4, 9.603482945673963E-4]
+[0.0, 0.8001546519983872, 0.11307587044966874, 0.0706943954663111, 0.005358360695211061, 0.004018770521408296, 0.004018770521408296, 0.001339590173802765, 0.001339590173802765]
+[0.0, 0.8197324290122764, 0.10938437555964901, 0.05533290331876264, 0.005183430703104048, 0.003887573027328037, 0.003887573027328037, 0.0012958576757760118, 0.0012958576757760118]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.6799562187200117, 0.18309585889142552, 0.1109186647802452, 0.008676419202772534, 0.006507314402079402, 0.006507314402079402, 0.002169104800693133, 0.002169104800693133]
+[0.0, 0.7536316369297211, 0.14094642570343813, 0.08538472382296745, 0.0066790711812911045, 0.00500930338596833, 0.00500930338596833, 0.001669767795322776, 0.001669767795322776]
+[0.0, 0.8776641177486589, 0.07489086475134488, 0.036798388881932376, 0.0035488762060212754, 0.0026616571545159573, 0.0026616571545159573, 8.872190515053187E-4, 8.872190515053187E-4]
+[0.0, 0.8877606247044596, 0.06956152146312419, 0.03278885485257653, 0.003296332993279887, 0.0024722497449599155, 0.0024722497449599155, 8.240832483199717E-4, 8.240832483199717E-4]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8781153389526876, 0.07461470819382837, 0.03666258317999332, 0.0035357898911635025, 0.002651842418372627, 0.002651842418372627, 8.839474727908754E-4, 8.839474727908754E-4]
+[0.0, 0.7636739126774683, 0.1352031650936477, 0.08190218160159697, 0.006406913542429035, 0.004805185156821778, 0.004805185156821778, 0.0016017283856072585, 0.0016017283856072585]
+[0.0, 0.7636739126774683, 0.1352031650936477, 0.08190218160159697, 0.006406913542429035, 0.004805185156821778, 0.004805185156821778, 0.0016017283856072585, 0.0016017283856072585]
+[0.0, 0.8269518742841203, 0.10593461053717833, 0.052053648265249775, 0.0050199556378172526, 0.0037649667283629396, 0.0037649667283629396, 0.001254988909454313, 0.001254988909454313]
+[0.0, 0.8339050117698473, 0.10167922837967916, 0.04996084620614523, 0.004818304548109342, 0.003613728411082007, 0.003613728411082007, 0.0012045761370273352, 0.0012045761370273352]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.8334744590355627, 0.10194273212392718, 0.05009043499975085, 0.004830791280253035, 0.0036230934601897773, 0.0036230934601897773, 0.0012076978200632586, 0.0012076978200632586]
+[0.0, 0.8136630682984837, 0.11201172104607209, 0.05840141008501151, 0.005307933523477701, 0.003980950142608277, 0.003980950142608277, 0.001326983380869425, 0.001326983380869425]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.691439365638592, 0.17652878795579866, 0.10693617616595472, 0.00836522341321822, 0.006273917559913667, 0.006273917559913667, 0.002091305853304555, 0.002091305853304555]
+[0.0, 0.691439365638592, 0.17652878795579866, 0.10693617616595472, 0.00836522341321822, 0.006273917559913667, 0.006273917559913667, 0.002091305853304555, 0.002091305853304555]
+[0.0, 0.8267276764834662, 0.10607182066374939, 0.05212112988522149, 0.005026457655854168, 0.003769843241890626, 0.003769843241890626, 0.0012566144139635417, 0.0012566144139635417]
+[0.0, 0.8453514255426829, 0.09118025494417908, 0.05050596001957053, 0.004320786497855739, 0.003240589873391805, 0.003240589873391805, 0.0010801966244639346, 0.0010801966244639346]
+[0.0, 0.8570562982159793, 0.08538167144930674, 0.045424008564922715, 0.004046007256597067, 0.0030345054424478013, 0.0030345054424478013, 0.0010115018141492666, 0.0010115018141492666]
+[0.0, 0.7802418051427921, 0.1282817203595793, 0.07323969969619694, 0.00607892493381058, 0.004559193700357936, 0.004559193700357936, 0.0015197312334526449, 0.0015197312334526449]
+[0.0, 0.7076618502391216, 0.16243685682434458, 0.10680895858792626, 0.007697444782869186, 0.0057730835871518905, 0.0057730835871518905, 0.0019243611957172962, 0.0019243611957172962]
+[0.0, 0.7182294821903746, 0.15555247369006125, 0.10410440684887837, 0.0073712124235619245, 0.0055284093176714445, 0.0055284093176714445, 0.001842803105890481, 0.001842803105890481]
+[0.0, 0.6335237024645047, 0.2015597140979974, 0.13626246884702678, 0.009551371530157006, 0.007163528647617757, 0.007163528647617757, 0.002387842882539251, 0.002387842882539251]
+[0.0, 0.8854436776593019, 0.07078784325864469, 0.033705143849501636, 0.0033544450775173673, 0.0025158338081380256, 0.0025158338081380256, 8.386112693793417E-4, 8.386112693793417E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8784747308870676, 0.07439475280803605, 0.03655441590988014, 0.003525366798338812, 0.002644025098754109, 0.002644025098754109, 8.813416995847028E-4, 8.813416995847028E-4]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.6839817079700277, 0.16920703135559784, 0.12275646536136159, 0.008018265104337627, 0.006013698828253221, 0.006013698828253221, 0.0020045662760844064, 0.0020045662760844064]
+[0.0, 0.6119678106572028, 0.20939004636554814, 0.14887485337023276, 0.009922429869005371, 0.007441822401754029, 0.007441822401754029, 0.0024806074672513423, 0.0024806074672513423]
+[0.0, 0.8304599885635464, 0.10351014658908313, 0.051314664367387824, 0.0049050668266609225, 0.0036788001199956925, 0.0036788001199956925, 0.0012262667066652304, 0.0012262667066652304]
+[0.0, 0.8731911373533426, 0.07718444505367811, 0.038651729210941066, 0.003657562794012684, 0.002743172095509514, 0.002743172095509514, 9.143906985031709E-4, 9.143906985031709E-4]
+[0.0, 0.7914912595267929, 0.12293601463002865, 0.06809590679593615, 0.005825606349080882, 0.004369204761810662, 0.004369204761810662, 0.0014564015872702203, 0.0014564015872702203]
+[0.0, 0.8205097121821786, 0.10857559165282964, 0.055479382323279904, 0.0051451046139040614, 0.0038588284604280467, 0.0038588284604280467, 0.0012862761534760151, 0.0012862761534760151]
+[0.0, 0.8542092553012622, 0.08680262370665658, 0.04664809393074704, 0.004113342353778072, 0.003085006765333554, 0.003085006765333554, 0.0010283355884445177, 0.0010283355884445177]
+[0.0, 0.9033055053585756, 0.06114513905651775, 0.026856845630641207, 0.0028975033180884914, 0.002173127488566367, 0.002173127488566367, 7.243758295221228E-4, 7.243758295221228E-4]
+[0.0, 0.8987811530267003, 0.06364584926178136, 0.02852498200998621, 0.0030160052338439117, 0.002262003925382936, 0.002262003925382936, 7.540013084609778E-4, 7.540013084609778E-4]
+[0.0, 0.8542508305270032, 0.08677787696555961, 0.046634783490163915, 0.004112169672424379, 0.0030841272543182846, 0.0030841272543182846, 0.0010280424181060945, 0.0010280424181060945]
+[0.0, 0.8750217138349538, 0.0761871332963274, 0.03796024423421346, 0.0036103028781684925, 0.00270772715862637, 0.00270772715862637, 9.025757195421229E-4, 9.025757195421229E-4]
+[0.0, 0.8065030037425722, 0.11557767301792514, 0.061488580114190526, 0.005476914375104156, 0.004107685781328118, 0.004107685781328118, 0.0013692285937760389, 0.0013692285937760389]
+[0.0, 0.9366611320471137, 0.04219345358782171, 0.015147112276357778, 0.0019994340295689346, 0.0014995755221767011, 0.0014995755221767011, 4.998585073922335E-4, 4.998585073922335E-4]
+[0.0, 0.7633911804045264, 0.13536486347094825, 0.08200022814655167, 0.006414575992657907, 0.004810931994493431, 0.004810931994493431, 0.0016036439981644765, 0.0016036439981644765]
+[0.0, 0.8780796000610619, 0.07463658113333414, 0.036673339633184816, 0.0035368263908063576, 0.0026526197931047686, 0.0026526197931047686, 8.842065977015892E-4, 8.842065977015892E-4]
+[0.0, 0.691439365638592, 0.17652878795579866, 0.10693617616595472, 0.00836522341321822, 0.006273917559913667, 0.006273917559913667, 0.002091305853304555, 0.002091305853304555]
+[0.0, 0.8781428293387467, 0.07459788350876884, 0.03665430930841157, 0.0035349926146908696, 0.002651244461018152, 0.002651244461018152, 8.837481536727172E-4, 8.837481536727172E-4]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8588956544920673, 0.08455248374630212, 0.044531718902142886, 0.004006714286495989, 0.0030050357148719915, 0.0030050357148719915, 0.001001678571623997, 0.001001678571623997]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8334601802632663, 0.10195147091029105, 0.05009473266309483, 0.004831205387782695, 0.003623404040837022, 0.003623404040837022, 0.0012078013469456737, 0.0012078013469456737]
+[0.0, 0.8333496790463713, 0.10201909902230177, 0.05012799162618604, 0.004834410101713689, 0.0036258075762852673, 0.0036258075762852673, 0.0012086025254284222, 0.0012086025254284222]
+[0.0, 0.8064789693865086, 0.11559202482132092, 0.061496222387028794, 0.005477594468380605, 0.004108195851285455, 0.004108195851285455, 0.001369398617095151, 0.001369398617095151]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.83339244963123, 0.10199292289684601, 0.05011511841485892, 0.0048331696856882605, 0.0036248772642661956, 0.0036248772642661956, 0.0012082924214220647, 0.0012082924214220647]
+[0.0, 0.8198666314048143, 0.10301006431866142, 0.062479196448887706, 0.004881369275878926, 0.0036610269569091946, 0.0036610269569091946, 0.0012203423189697312, 0.0012203423189697312]
+[0.0, 0.8629849077399082, 0.08339498116020203, 0.041764521022634477, 0.003951863359085045, 0.002963897519313784, 0.002963897519313784, 9.87965839771261E-4, 9.87965839771261E-4]
+[0.0, 0.9046078067655536, 0.060490132929074354, 0.026302667275374607, 0.002866464343332357, 0.002149848257499268, 0.002149848257499268, 7.166160858330891E-4, 7.166160858330891E-4]
+[0.0, 0.8784199395929837, 0.07442828623880852, 0.03657090659651472, 0.0035269558572309733, 0.0026452168929232303, 0.0026452168929232303, 8.817389643077431E-4, 8.817389643077431E-4]
+[0.0, 0.8369309203970956, 0.1001648544082285, 0.04866459785150688, 0.004746542447723092, 0.0035599068357923197, 0.0035599068357923197, 0.001186635611930773, 0.001186635611930773]
+[0.0, 0.8733246319680715, 0.07710321203137771, 0.03861101586038194, 0.0036537133800562263, 0.00274028503504217, 0.00274028503504217, 9.134283450140564E-4, 9.134283450140564E-4]
+[0.0, 0.8832578092098343, 0.07192406566489014, 0.03459326234157286, 0.0034082875945674923, 0.00255621569592562, 0.00255621569592562, 8.520718986418729E-4, 8.520718986418729E-4]
+[0.0, 0.8502078513671621, 0.08889651012724521, 0.04825794054457761, 0.00421256598700504, 0.0031594244902537804, 0.0031594244902537804, 0.0010531414967512598, 0.0010531414967512598]
+[0.0, 0.8092443467844974, 0.11430461030017008, 0.0602012808216647, 0.005416587364556017, 0.004062440523417013, 0.004062440523417013, 0.001354146841139004, 0.001354146841139004]
+[0.0, 0.7982177082263461, 0.11975097772485409, 0.06500728594177191, 0.005674676035676126, 0.004256007026757096, 0.004256007026757096, 0.0014186690089190315, 0.0014186690089190315]
+[0.0, 0.8506486119227654, 0.0886350065191802, 0.04811585945028395, 0.00420017403592353, 0.003150130526942648, 0.003150130526942648, 0.0010500435089808823, 0.0010500435089808823]
+[0.0, 0.8379089408205113, 0.09493632308166768, 0.05365840677152763, 0.004498776442097747, 0.00337408233157331, 0.00337408233157331, 0.0011246941105244365, 0.0011246941105244365]
+[0.0, 0.8362326867401776, 0.10059363039544762, 0.04887309990650632, 0.004766860985956125, 0.003575145739467098, 0.003575145739467098, 0.001191715246489031, 0.001191715246489031]
+[0.0, 0.8335634441474653, 0.1018882721225307, 0.05006365202723869, 0.004828210567588313, 0.0036211579256912353, 0.0036211579256912353, 0.0012070526418970782, 0.0012070526418970782]
+[2.0, 0.24970033743228856, 0.31767818249800156, 0.3874597418477331, 0.015053912740659028, 0.011290434555494274, 0.011290434555494274, 0.0037634781851647566, 0.0037634781851647566]
+[2.0, 0.26909395273559217, 0.31591774165126546, 0.37007683503010236, 0.014970490194346696, 0.011227867645760024, 0.011227867645760024, 0.0037426225485866736, 0.0037426225485866736]
+[2.0, 0.19163338802901375, 0.3440467969113631, 0.4154094641628683, 0.0163034502989184, 0.012227587724188803, 0.012227587724188803, 0.004075862574729599, 0.004075862574729599]
+[2.0, 0.21192033416434955, 0.3441091679759407, 0.3950512801730829, 0.01630640589554235, 0.012229804421656767, 0.012229804421656767, 0.004076601473885588, 0.004076601473885588]
+[0.0, 0.8187476462834519, 0.11065895079375786, 0.05486191475961533, 0.0052438293877250805, 0.0039328720407938115, 0.0039328720407938115, 0.00131095734693127, 0.00131095734693127]
+[2.0, 0.11483097050037465, 0.3326277980358495, 0.5052542272945733, 0.01576233472306753, 0.01182175104230065, 0.01182175104230065, 0.003940583680766881, 0.003940583680766881]
+[2.0, 0.13150803477498627, 0.33767936325550735, 0.4828074576237658, 0.016001714781913576, 0.012001286086435185, 0.012001286086435185, 0.004000428695478394, 0.004000428695478394]
+[2.0, 0.11748307111358669, 0.33354178670883555, 0.5015582036299342, 0.01580564618254797, 0.011854234636910979, 0.011854234636910979, 0.0039514115456369915, 0.0039514115456369915]
+[2.0, 0.1601050653351733, 0.34311238518149795, 0.44800503634585537, 0.016259171045824503, 0.01219437828436838, 0.01219437828436838, 0.004064792761456125, 0.004064792761456125]
+[2.0, 0.15336679705890227, 0.3421462319993221, 0.455846807989174, 0.016213387650867325, 0.012160040738150496, 0.012160040738150496, 0.00405334691271683, 0.00405334691271683]
+[0.0, 0.8414977929595386, 0.10022538362996078, 0.044028591117362084, 0.004749410764379442, 0.003562058073284582, 0.003562058073284582, 0.0011873526910948602, 0.0011873526910948602]
+[0.0, 0.8535880645033138, 0.08717237363158471, 0.04684697044701509, 0.004130863806028789, 0.0030981478545215923, 0.0030981478545215923, 0.001032715951507197, 0.001032715951507197]
+[0.0, 0.8429558605861057, 0.09289621308095916, 0.050941622947584586, 0.004402101128450095, 0.0033015758463375714, 0.0033015758463375714, 0.0011005252821125234, 0.0011005252821125234]
+[0.0, 0.8774958887275224, 0.07499382426024762, 0.036849021473393244, 0.0035537551796122717, 0.0026653163847092046, 0.0026653163847092046, 8.884387949030679E-4, 8.884387949030679E-4]
+[0.0, 0.8831810569737343, 0.07197134053450181, 0.03461601902214864, 0.003410527823205053, 0.0025578958674037904, 0.0025578958674037904, 8.526319558012632E-4, 8.526319558012632E-4]
+[0.0, 0.6189054791468692, 0.19495087765532992, 0.15842905344038155, 0.009238196585806432, 0.0069286474393548255, 0.0069286474393548255, 0.002309549146451608, 0.002309549146451608]
+[0.0, 0.543631717493875, 0.2356557566821107, 0.18721125258550242, 0.011167091079503979, 0.008375318309627986, 0.008375318309627986, 0.002791772769875994, 0.002791772769875994]
+[0.0, 0.8150753056634119, 0.111861995766864, 0.05716018323144529, 0.005300838446092953, 0.003975628834569716, 0.003975628834569716, 0.001325209611523238, 0.001325209611523238]
+[0.0, 0.8786253793641079, 0.07430255273165773, 0.036509074848478026, 0.003520997685252205, 0.002640748263939154, 0.002640748263939154, 8.80249421313051E-4, 8.80249421313051E-4]
+[0.0, 0.8781153389526876, 0.07461470819382837, 0.03666258317999332, 0.0035357898911635025, 0.002651842418372627, 0.002651842418372627, 8.839474727908754E-4, 8.839474727908754E-4]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.854154931889276, 0.08683495852253446, 0.04666548574756531, 0.004114874613541339, 0.0030861559601560048, 0.0030861559601560048, 0.0010287186533853346, 0.0010287186533853346]
+[0.0, 0.8653734323210435, 0.08118266878209876, 0.04190281537998253, 0.003847027838958459, 0.0028852708792188445, 0.0028852708792188445, 9.617569597396145E-4, 9.617569597396145E-4]
+[0.0, 0.8575429823106847, 0.0850910493005495, 0.04526926201967465, 0.0040322354563636, 0.0030241765922727, 0.0030241765922727, 0.0010080588640908998, 0.0010080588640908998]
+[0.0, 0.7509258234426442, 0.14004883237877147, 0.08911573421906681, 0.0066365366531724946, 0.004977402489879372, 0.004977402489879372, 0.0016591341632931234, 0.0016591341632931234]
+[0.0, 0.7556752178112142, 0.13977769344394628, 0.08467602441505367, 0.006623688109928643, 0.004967766082446484, 0.004967766082446484, 0.0016559220274821606, 0.0016559220274821606]
+[0.0, 0.6823533423291831, 0.1817249840218766, 0.11008730223490534, 0.00861145713801166, 0.006458592853508746, 0.006458592853508746, 0.0021528642845029147, 0.0021528642845029147]
+[0.0, 0.8205919562403486, 0.10982688865671565, 0.053967954485106356, 0.005204400205943236, 0.0039033001544574284, 0.0039033001544574284, 0.0013011000514858088, 0.0013011000514858088]
+[0.0, 0.833128586294404, 0.10215441047931341, 0.050194536785528016, 0.004840822146918201, 0.003630616610188651, 0.003630616610188651, 0.0012102055367295501, 0.0012102055367295501]
+[0.0, 0.8625516819107997, 0.08262353561721354, 0.0430788625690916, 0.003915306634298345, 0.0029364799757237593, 0.0029364799757237593, 9.78826658574586E-4, 9.78826658574586E-4]
+[0.0, 0.8272009309334493, 0.10517721561474073, 0.052669659249618736, 0.004984064734063845, 0.0037380485505478845, 0.0037380485505478845, 0.001246016183515961, 0.001246016183515961]
+[0.0, 0.8482667098047203, 0.08975556015874844, 0.04921790787945957, 0.0042532740523572804, 0.003189955539267961, 0.003189955539267961, 0.0010633185130893201, 0.0010633185130893201]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.7509258234426442, 0.14004883237877147, 0.08911573421906681, 0.0066365366531724946, 0.004977402489879372, 0.004977402489879372, 0.0016591341632931234, 0.0016591341632931234]
+[0.0, 0.7914912595267929, 0.12293601463002865, 0.06809590679593615, 0.005825606349080882, 0.004369204761810662, 0.004369204761810662, 0.0014564015872702203, 0.0014564015872702203]
+[0.0, 0.8830830198904307, 0.07203172560727145, 0.03464508657520563, 0.0034133893090306277, 0.002560041981772971, 0.002560041981772971, 8.533473272576567E-4, 8.533473272576567E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8415200544403653, 0.09313076922290416, 0.05210952800147647, 0.004413216111751307, 0.0033099120838134804, 0.0033099120838134804, 0.0011033040279378266, 0.0011033040279378266]
+[0.0, 0.8621037469046493, 0.08289272826178293, 0.04321933598928786, 0.00392806294809336, 0.002946047211070021, 0.002946047211070021, 9.8201573702334E-4, 9.8201573702334E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8331499953770541, 0.10214130786247665, 0.05018809301279279, 0.004840201249225498, 0.003630150936919124, 0.003630150936919124, 0.0012100503123063742, 0.0012100503123063742]
+[0.0, 0.8784747308870676, 0.07439475280803605, 0.03655441590988014, 0.003525366798338812, 0.002644025098754109, 0.002644025098754109, 8.813416995847028E-4, 8.813416995847028E-4]
+[0.0, 0.8784610515009056, 0.07440312488208124, 0.0365585330319328, 0.003525763528360194, 0.002644322646270146, 0.002644322646270146, 8.814408820900485E-4, 8.814408820900485E-4]
+[0.0, 0.8966915483592431, 0.06477473571701796, 0.029325215563887848, 0.003069500119950391, 0.0023021250899627936, 0.0023021250899627936, 7.673750299875977E-4, 7.673750299875977E-4]
+[0.0, 0.8540589809328777, 0.0868920712089404, 0.046696204768787566, 0.0041175810297981305, 0.0030881857723485985, 0.0030881857723485985, 0.0010293952574495324, 0.0010293952574495324]
+[2.0, 0.14859824168226524, 0.33662066476484886, 0.46692645581013326, 0.015951545914250968, 0.011963659435688228, 0.011963659435688228, 0.003987886478562741, 0.003987886478562741]
+[2.0, 0.13012965276560956, 0.33254517183787213, 0.4900499175257049, 0.015758419290271157, 0.011818814467703371, 0.011818814467703371, 0.003939604822567789, 0.003939604822567789]
+[2.0, 0.13912070741995464, 0.33472836535625333, 0.47856530238540873, 0.01586187494612782, 0.011896406209595868, 0.011896406209595868, 0.003965468736531955, 0.003965468736531955]
+[2.0, 0.12440022799773759, 0.330936479986124, 0.49761672885680064, 0.01568218771977929, 0.011761640789834469, 0.011761640789834469, 0.003920546929944821, 0.003920546929944821]
+[2.0, 0.14222530471153969, 0.3353922837020568, 0.47470240284573834, 0.015893336246888413, 0.011920002185166312, 0.011920002185166312, 0.0039733340617221025, 0.0039733340617221025]
+[0.0, 0.8440475204121306, 0.09805940241810375, 0.04395276490977032, 0.004646770753331759, 0.0034850780649988197, 0.0034850780649988197, 0.0011616926883329397, 0.0011616926883329397]
+[0.0, 0.7739420509733621, 0.13502045118788908, 0.07184273216988188, 0.00639825522295564, 0.0047986914172167315, 0.0047986914172167315, 0.0015995638057389099, 0.0015995638057389099]
+[0.0, 0.8905909170315814, 0.06800687431002862, 0.03173422129226461, 0.0032226624553751883, 0.0024169968415313917, 0.0024169968415313917, 8.05665613843797E-4, 8.05665613843797E-4]
+[0.0, 0.8334851460983127, 0.10193619150835383, 0.05008721837899846, 0.004830481338111785, 0.003622861003583839, 0.003622861003583839, 0.0012076203345279459, 0.0012076203345279459]
+[0.0, 0.8736116042518245, 0.0773710724521198, 0.03801810360599041, 0.003666406563355185, 0.002749804922516389, 0.002749804922516389, 9.16601640838796E-4, 9.16601640838796E-4]
+[0.0, 0.8276083266962431, 0.10553285818978898, 0.051856062082874306, 0.005000917677031286, 0.0037506882577734648, 0.0037506882577734648, 0.0012502294192578212, 0.0012502294192578212]
+[0.0, 0.8385468315613365, 0.09864690826513846, 0.04878242695826899, 0.004674611071751938, 0.0035059583038139545, 0.0035059583038139545, 0.0011686527679379845, 0.0011686527679379845]
+[0.0, 0.7709077057657014, 0.13868669726031888, 0.0706896307490076, 0.006571988741657352, 0.004928991556243015, 0.004928991556243015, 0.0016429971854143375, 0.0016429971854143375]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.8781153389526876, 0.07461470819382837, 0.03666258317999332, 0.0035357898911635025, 0.002651842418372627, 0.002651842418372627, 8.839474727908754E-4, 8.839474727908754E-4]
+[0.0, 0.5277400616546339, 0.24284895599416265, 0.19488711013609522, 0.011507957405036044, 0.008630968053777034, 0.008630968053777034, 0.0028769893512590105, 0.0028769893512590105]
+[0.0, 0.7027600491380132, 0.16286504631790139, 0.11122169795783989, 0.007717735528748507, 0.005788301646561381, 0.005788301646561381, 0.0019294338821871262, 0.0019294338821871262]
+[0.0, 0.8568512950567405, 0.09051915022437795, 0.03976117913714064, 0.004289458527247033, 0.003217093895435275, 0.003217093895435275, 0.001072364631811758, 0.001072364631811758]
+[0.0, 0.833203508473273, 0.10210855719972703, 0.050171986476199956, 0.004838649283599924, 0.003628986962699944, 0.003628986962699944, 0.0012096623208999807, 0.0012096623208999807]
+[0.0, 0.9193838619415828, 0.05223689349295321, 0.02095314784422333, 0.002475365573746834, 0.0018565241803101256, 0.0018565241803101256, 6.188413934367084E-4, 6.188413934367084E-4]
+[0.0, 0.8388827094256517, 0.09436615420446752, 0.0533358633420467, 0.0044717576759447895, 0.0033538182569585926, 0.0033538182569585926, 0.0011179394189861972, 0.0011179394189861972]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8669009853706401, 0.08147803577341493, 0.040037905402472755, 0.0038610244844906817, 0.0028957683633680114, 0.0028957683633680114, 9.652561211226702E-4, 9.652561211226702E-4]
+[0.0, 0.8784747308870676, 0.07439475280803605, 0.03655441590988014, 0.003525366798338812, 0.002644025098754109, 0.002644025098754109, 8.813416995847028E-4, 8.813416995847028E-4]
+[0.0, 0.865875009399791, 0.0808802869353146, 0.041746607329890474, 0.003832698778334736, 0.0028745240837510524, 0.0028745240837510524, 9.581746945836839E-4, 9.581746945836839E-4]
+[0.0, 0.8784774929098204, 0.07439306239158176, 0.03655358461641853, 0.0035252866940597024, 0.002643965020544777, 0.002643965020544777, 8.813216735149254E-4, 8.813216735149254E-4]
+[0.0, 0.8781455319420784, 0.07459622945955292, 0.03665349589709724, 0.0035349142337571526, 0.0026511856753178645, 0.0026511856753178645, 8.837285584392879E-4, 8.837285584392879E-4]
+[0.0, 0.8782471387192046, 0.07453404399980998, 0.03662291498364725, 0.0035319674324460057, 0.002648975574334504, 0.002648975574334504, 8.829918581115012E-4, 8.829918581115012E-4]
+[0.0, 0.8981141687886341, 0.06397415066650872, 0.028816992887506384, 0.0030315625524502433, 0.002273671914337683, 0.002273671914337683, 7.578906381125606E-4, 7.578906381125606E-4]
+[2.0, 0.008618749038806382, 0.26335264785913803, 0.6905898868227163, 0.012479572093113156, 0.00935967906983487, 0.00935967906983487, 0.0031198930232782885, 0.0031198930232782885]
+[2.0, 0.005682261323587051, 0.23648743191564092, 0.7242108009798581, 0.01120650192697132, 0.008404876445228492, 0.008404876445228492, 0.00280162548174283, 0.00280162548174283]
+[2.0, 0.006001868494252319, 0.26404780163562025, 0.6924127891999198, 0.012512513556735919, 0.009384385167551941, 0.009384385167551941, 0.0031281283891839793, 0.0031281283891839793]
+[2.0, 0.006001868494252319, 0.26404780163562025, 0.6924127891999198, 0.012512513556735919, 0.009384385167551941, 0.009384385167551941, 0.0031281283891839793, 0.0031281283891839793]
+[2.0, 0.006001868494252319, 0.26404780163562025, 0.6924127891999198, 0.012512513556735919, 0.009384385167551941, 0.009384385167551941, 0.0031281283891839793, 0.0031281283891839793]
+[2.0, 0.006001868494252319, 0.26404780163562025, 0.6924127891999198, 0.012512513556735919, 0.009384385167551941, 0.009384385167551941, 0.0031281283891839793, 0.0031281283891839793]
+[2.0, 0.008618749038806382, 0.26335264785913803, 0.6905898868227163, 0.012479572093113156, 0.00935967906983487, 0.00935967906983487, 0.0031198930232782885, 0.0031198930232782885]
+[2.0, 0.008618749038806382, 0.26335264785913803, 0.6905898868227163, 0.012479572093113156, 0.00935967906983487, 0.00935967906983487, 0.0031198930232782885, 0.0031198930232782885]
+[2.0, 0.008618749038806382, 0.26335264785913803, 0.6905898868227163, 0.012479572093113156, 0.00935967906983487, 0.00935967906983487, 0.0031198930232782885, 0.0031198930232782885]
+[0.0, 0.6981278855026096, 0.17268761867157514, 0.10463489356072632, 0.008183200755029648, 0.006137400566272238, 0.006137400566272238, 0.0020458001887574116, 0.0020458001887574116]
+[0.0, 0.6163048970931881, 0.21949491335840196, 0.13299637271654402, 0.010401272277288615, 0.007800954207966463, 0.007800954207966463, 0.0026003180693221534, 0.0026003180693221534]
+[0.0, 0.861617865901904, 0.08318472476355031, 0.043371709708911535, 0.003941899875211301, 0.0029564249064084752, 0.0029564249064084752, 9.85474968802825E-4, 9.85474968802825E-4]
+[0.0, 0.8029375875154837, 0.11732939241479108, 0.0630532491634759, 0.005559923635416535, 0.004169942726562402, 0.004169942726562402, 0.0013899809088541335, 0.0013899809088541335]
+[0.0, 0.8987811530267003, 0.06364584926178136, 0.02852498200998621, 0.0030160052338439117, 0.002262003925382936, 0.002262003925382936, 7.540013084609778E-4, 7.540013084609778E-4]
+[0.0, 0.5908873355438916, 0.2165782677583009, 0.16174521578472664, 0.010263060304360243, 0.007697295228270184, 0.007697295228270184, 0.0025657650760900603, 0.0025657650760900603]
+[0.0, 0.5908873355438916, 0.2165782677583009, 0.16174521578472664, 0.010263060304360243, 0.007697295228270184, 0.007697295228270184, 0.0025657650760900603, 0.0025657650760900603]
+[0.0, 0.5908873355438916, 0.2165782677583009, 0.16174521578472664, 0.010263060304360243, 0.007697295228270184, 0.007697295228270184, 0.0025657650760900603, 0.0025657650760900603]
+[0.0, 0.5270859192581756, 0.24217385892197069, 0.19631232269615828, 0.011475966374565086, 0.008606974780923817, 0.008606974780923817, 0.002868991593641271, 0.002868991593641271]
+[0.0, 0.8051591105201301, 0.11712217284248373, 0.06106840446199923, 0.005550104058462455, 0.004162578043846842, 0.004162578043846842, 0.0013875260146156134, 0.0013875260146156134]
+[0.0, 0.5451681463340808, 0.23583197254488067, 0.18547355669832993, 0.011175441474236157, 0.008381581105677119, 0.008381581105677119, 0.0027938603685590388, 0.0027938603685590388]
+[0.0, 0.8642390918352814, 0.08186651848245019, 0.04225608878361502, 0.003879433632884459, 0.002909575224663345, 0.002909575224663345, 9.698584082211148E-4, 9.698584082211148E-4]
+[0.0, 0.8511273345978582, 0.0883509796675934, 0.04796154142741388, 0.004186714769044796, 0.0031400360767835974, 0.0031400360767835974, 0.0010466786922611988, 0.0010466786922611988]
+[0.0, 0.8639237875870596, 0.08192789723844628, 0.042501288554455265, 0.003882342206679581, 0.0029117566550096864, 0.0029117566550096864, 9.705855516698952E-4, 9.705855516698952E-4]
+[0.0, 0.878148300409038, 0.07459453510042145, 0.03665266266260499, 0.0035348339426451987, 0.0026511254569838993, 0.0026511254569838993, 8.837084856612995E-4, 8.837084856612995E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8747573988815306, 0.07646485289820769, 0.03790735843580547, 0.0036234632614853524, 0.002717597446114014, 0.002717597446114014, 9.058658153713379E-4, 9.058658153713379E-4]
+[0.0, 0.8732029435956816, 0.07762117848854964, 0.03814110267304872, 0.003678258414240003, 0.0027586938106800027, 0.0027586938106800027, 9.195646035600007E-4, 9.195646035600007E-4]
+[0.0, 0.8334352114330917, 0.10196675214455483, 0.05010224784950574, 0.004831929524282616, 0.0036239471432119624, 0.0036239471432119624, 0.0012079823810706536, 0.0012079823810706536]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.8575586344948742, 0.08508170263400193, 0.04526428524203204, 0.004031792543030622, 0.0030238444072729674, 0.0030238444072729674, 0.0010079481357576554, 0.0010079481357576554]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.9008634593327107, 0.06251330408956358, 0.027736225664719515, 0.0029623369710020703, 0.0022217527282515554, 0.0022217527282515554, 7.405842427505175E-4, 7.405842427505175E-4]
+[0.0, 0.854154931889276, 0.08683495852253446, 0.04666548574756531, 0.004114874613541339, 0.0030861559601560048, 0.0030861559601560048, 0.0010287186533853346, 0.0010287186533853346]
+[0.0, 0.7917749616560941, 0.12276879551759814, 0.06800319596802061, 0.005817682286095804, 0.004363261714571854, 0.004363261714571854, 0.0014544205715239509, 0.0014544205715239509]
+[2.0, 0.25129529230874076, 0.320301028172829, 0.3828690725371582, 0.01517820232709078, 0.011383651745318088, 0.011383651745318088, 0.0037945505817726945, 0.0037945505817726945]
+[2.0, 0.2807603898026946, 0.3172214483183013, 0.3569213538618606, 0.015032269339047942, 0.011274202004285958, 0.011274202004285958, 0.0037580673347619845, 0.0037580673347619845]
+[2.0, 0.20910889495922957, 0.3470774402708386, 0.39447247181481276, 0.016447064318373103, 0.01233529823877983, 0.01233529823877983, 0.004111766079593275, 0.004111766079593275]
+[2.0, 0.18141862568640374, 0.34658325020613695, 0.42272718615744775, 0.01642364598333725, 0.012317734487502941, 0.012317734487502941, 0.004105911495834312, 0.004105911495834312]
+[0.0, 0.7912468545985861, 0.12358181104896519, 0.06760270765071966, 0.00585620890057641, 0.0043921566754323085, 0.0043921566754323085, 0.0014640522251441023, 0.0014640522251441023]
+[0.0, 0.7473355512650265, 0.15199807926931508, 0.07905803170627423, 0.007202779253128085, 0.005402084439846065, 0.005402084439846065, 0.001800694813282021, 0.001800694813282021]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.877528994338864, 0.07497356297047328, 0.036839057535545054, 0.0035527950517058567, 0.002664596288779393, 0.002664596288779393, 8.881987629264641E-4, 8.881987629264641E-4]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8334744590355627, 0.10194273212392718, 0.05009043499975085, 0.004830791280253035, 0.0036230934601897773, 0.0036230934601897773, 0.0012076978200632586, 0.0012076978200632586]
+[0.0, 0.8484614968211249, 0.08964036915284498, 0.04915468764274676, 0.004247815461094438, 0.003185861595820829, 0.003185861595820829, 0.0010619538652736095, 0.0010619538652736095]
+[0.0, 0.8782281385859511, 0.07457250359041773, 0.03659798803730953, 0.003533789928773886, 0.002650342446580415, 0.002650342446580415, 8.834474821934713E-4, 8.834474821934713E-4]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.8830830198904307, 0.07203172560727145, 0.03464508657520563, 0.0034133893090306277, 0.002560041981772971, 0.002560041981772971, 8.533473272576567E-4, 8.533473272576567E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8850604102568903, 0.07102461794714882, 0.03381797622068186, 0.0033656651917597456, 0.0025242488938198096, 0.0025242488938198096, 8.414162979399362E-4, 8.414162979399362E-4]
+[0.0, 0.8103000140562511, 0.1136722139189419, 0.05986791261062777, 0.005386619804726574, 0.004039964853544932, 0.004039964853544932, 0.0013466549511816433, 0.0013466549511816433]
+[0.0, 0.8540589809328777, 0.0868920712089404, 0.046696204768787566, 0.0041175810297981305, 0.0030881857723485985, 0.0030881857723485985, 0.0010293952574495324, 0.0010293952574495324]
+[0.0, 0.925248818994636, 0.049734218620744106, 0.017946650711457336, 0.0023567705577207873, 0.0017675779182905907, 0.0017675779182905907, 5.891926394301967E-4, 5.891926394301967E-4]
+[0.0, 0.8482667098047203, 0.08975556015874844, 0.04921790787945957, 0.0042532740523572804, 0.003189955539267961, 0.003189955539267961, 0.0010633185130893201, 0.0010633185130893201]
+[0.0, 0.8044883167655972, 0.11678071494713847, 0.062129198419574, 0.005533923289230154, 0.004150442466922617, 0.004150442466922617, 0.0013834808223075383, 0.0013834808223075383]
+[0.0, 0.8807589345445448, 0.07324357780102204, 0.035585040500900625, 0.0034708157178442466, 0.0026031117883831855, 0.0026031117883831855, 8.677039294610614E-4, 8.677039294610614E-4]
+[0.0, 0.8701771979205339, 0.07877546284503133, 0.039848468719161555, 0.003732956838424335, 0.002799717628818252, 0.002799717628818252, 9.332392096060838E-4, 9.332392096060838E-4]
+[0.0, 0.7191681797475469, 0.15661900050022465, 0.1019475629896765, 0.007421752254183986, 0.005566314190637991, 0.005566314190637991, 0.0018554380635459962, 0.0018554380635459962]
+[0.0, 0.6936203040366972, 0.1747418561231201, 0.10679620324871046, 0.008280545530490728, 0.006210409147868047, 0.006210409147868047, 0.0020701363826226816, 0.0020701363826226816]
+[0.0, 0.8388827094256517, 0.09436615420446752, 0.0533358633420467, 0.0044717576759447895, 0.0033538182569585926, 0.0033538182569585926, 0.0011179394189861972, 0.0011179394189861972]
+[0.0, 0.908724221533621, 0.05820033781635734, 0.024801569274200835, 0.00275795712527357, 0.0020684678439551792, 0.0020684678439551792, 6.894892813183924E-4, 6.894892813183924E-4]
+[0.0, 0.8660001566581224, 0.08080484033366904, 0.041707632306442546, 0.003829123567255334, 0.0028718426754415012, 0.0028718426754415012, 9.572808918138333E-4, 9.572808918138333E-4]
+[0.0, 0.9514474175784119, 0.03332273373053747, 0.010492625109167986, 0.0015790745272942438, 0.0011843058954706831, 0.0011843058954706831, 3.9476863182356096E-4, 3.9476863182356096E-4]
+[0.0, 0.8314304312903578, 0.09806923554010537, 0.05655862301410472, 0.004647236718477421, 0.0034854275388580625, 0.0034854275388580625, 0.001161809179619355, 0.001161809179619355]
+[0.0, 0.862737224623118, 0.08251203111690351, 0.043020676050183775, 0.003910022736598293, 0.00293251705244872, 0.00293251705244872, 9.77505684149573E-4, 9.77505684149573E-4]
+[0.0, 0.8654661281588112, 0.08112678599401939, 0.04187394673436505, 0.003844379704268075, 0.0028832847782010564, 0.0028832847782010564, 9.610949260670185E-4, 9.610949260670185E-4]
+[0.0, 0.8877606247044596, 0.06956152146312419, 0.03278885485257653, 0.003296332993279887, 0.0024722497449599155, 0.0024722497449599155, 8.240832483199717E-4, 8.240832483199717E-4]
+[0.0, 0.7823131864599019, 0.12069830058574084, 0.07982981161695929, 0.005719567112466111, 0.004289675334349584, 0.004289675334349584, 0.0014298917781165276, 0.0014298917781165276]
+[0.0, 0.773326373378267, 0.1296827424676262, 0.07855493736928813, 0.0061453155949394885, 0.004608986696204617, 0.004608986696204617, 0.001536328898734872, 0.001536328898734872]
+[0.0, 0.878994417009049, 0.07407669369485079, 0.03639800479314092, 0.0035102948343197133, 0.002632721125739785, 0.002632721125739785, 8.775737085799281E-4, 8.775737085799281E-4]
+[0.0, 0.8784774929098204, 0.07439306239158176, 0.03655358461641853, 0.0035252866940597024, 0.002643965020544777, 0.002643965020544777, 8.813216735149254E-4, 8.813216735149254E-4]
+[0.0, 0.6272057372451734, 0.20272151094967017, 0.1412534739514428, 0.009606425951237889, 0.007204819463428418, 0.007204819463428418, 0.0024016064878094718, 0.0024016064878094718]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.7627229091480014, 0.1357470564259718, 0.0822319731663359, 0.006432687086563624, 0.004824515314922719, 0.004824515314922719, 0.0016081717716409057, 0.0016081717716409057]
+[0.0, 0.6906502262174704, 0.17698009127738312, 0.10720985412183873, 0.008386609461102527, 0.006289957095826897, 0.006289957095826897, 0.002096652365275632, 0.002096652365275632]
+[0.0, 0.8831624977108254, 0.07198277194912556, 0.03462152175865993, 0.0034110695271297423, 0.0025583021453473073, 0.0025583021453473073, 8.527673817824355E-4, 8.527673817824355E-4]
+[0.0, 0.8781318206405861, 0.07460462105994993, 0.036657622632224725, 0.0035353118890797124, 0.0026514839168097844, 0.0026514839168097844, 8.838279722699279E-4, 8.838279722699279E-4]
+[0.0, 0.8780356723870566, 0.07466346577419529, 0.03668656069434722, 0.003538100381466983, 0.002653575286100238, 0.002653575286100238, 8.845250953667458E-4, 8.845250953667458E-4]
+[0.0, 0.8794587441902876, 0.07393065848957615, 0.03610047346136069, 0.0035033746195917747, 0.002627530964693831, 0.002627530964693831, 8.758436548979434E-4, 8.758436548979434E-4]
+[0.0, 0.9086603346925847, 0.058241065145242, 0.02481893891135675, 0.0027598870836055183, 0.002069915312704139, 0.002069915312704139, 6.899717709013795E-4, 6.899717709013795E-4]
+[0.0, 0.8784747308870676, 0.07439475280803605, 0.03655441590988014, 0.003525366798338812, 0.002644025098754109, 0.002644025098754109, 8.813416995847028E-4, 8.813416995847028E-4]
+[0.0, 0.8709601953248396, 0.07781460106825228, 0.04016293104019194, 0.0036874241889054858, 0.002765568141679115, 0.002765568141679115, 9.218560472263712E-4, 9.218560472263712E-4]
+[0.0, 0.8784747308870676, 0.07439475280803605, 0.03655441590988014, 0.003525366798338812, 0.002644025098754109, 0.002644025098754109, 8.813416995847028E-4, 8.813416995847028E-4]
+[0.0, 0.6518374875643003, 0.18274509804304342, 0.1394380216176381, 0.0086597975916727, 0.006494848193754527, 0.006494848193754527, 0.0021649493979181748, 0.0021649493979181748]
+[0.0, 0.5770875414196219, 0.22376988402805206, 0.16733101971097125, 0.010603851613784894, 0.007952888710338673, 0.007952888710338673, 0.002650962903446223, 0.002650962903446223]
+[0.0, 0.8240155874148097, 0.10744360303788777, 0.053266421372868786, 0.005091462724811279, 0.00381859704360846, 0.00381859704360846, 0.0012728656812028196, 0.0012728656812028196]
+[0.0, 0.8923571040628842, 0.0671042999098344, 0.030998920364738596, 0.0031798918875142325, 0.0023849189156356725, 0.0023849189156356725, 7.949729718785579E-4, 7.949729718785579E-4]
+[0.0, 0.7893823827424344, 0.12417902162040538, 0.06878506833798159, 0.005884509099726272, 0.004413381824794705, 0.004413381824794705, 0.0014711272749315678, 0.0014711272749315678]
+[0.0, 0.91322367652685, 0.058083597901288746, 0.020435450165719456, 0.0027524251353806036, 0.002064318851535455, 0.002064318851535455, 6.881062838451508E-4, 6.881062838451508E-4]
+[0.0, 0.764502076770671, 0.13472952645972977, 0.08161498951669945, 0.0063844690842999345, 0.004788351813224952, 0.004788351813224952, 0.0015961172710749834, 0.0015961172710749834]
+[0.0, 0.6770072045373988, 0.17260145362231488, 0.12585398896345557, 0.00817911762561025, 0.00613433821920769, 0.00613433821920769, 0.0020447794064025623, 0.0020447794064025623]
+[0.0, 0.8982223158141839, 0.06426866635171954, 0.028372461263454073, 0.003045518856880899, 0.002284139142660673, 0.002284139142660673, 7.613797142202247E-4, 7.613797142202247E-4]
+[0.0, 0.7398669313928232, 0.14927296538232812, 0.08963917286946496, 0.0070736434517945515, 0.005305232588845915, 0.005305232588845915, 0.0017684108629486377, 0.0017684108629486377]
+[0.0, 0.7793630197991397, 0.12889925875983307, 0.07341315619910943, 0.006108188413972568, 0.004581141310479427, 0.004581141310479427, 0.0015270471034931417, 0.0015270471034931417]
+[0.0, 0.6805659375991298, 0.18282295880296123, 0.11062064198829392, 0.008663487203205063, 0.006497615402403799, 0.006497615402403799, 0.0021658718008012653, 0.0021658718008012653]
+[0.0, 0.8769734590416072, 0.07531356136641251, 0.03700625961439411, 0.0035689066591955074, 0.0026766799943966305, 0.0026766799943966305, 8.922266647988766E-4, 8.922266647988766E-4]
+[0.0, 0.8845345452614012, 0.07134948613007609, 0.03397278915080428, 0.003381059819239505, 0.002535794864429629, 0.002535794864429629, 8.45264954809876E-4, 8.45264954809876E-4]
+[0.0, 0.8721987944851549, 0.07778829641897898, 0.03895437604841754, 0.003686177682482792, 0.0027646332618620944, 0.0027646332618620944, 9.215444206206978E-4, 9.215444206206978E-4]
+[0.0, 0.8721987944851549, 0.07778829641897898, 0.03895437604841754, 0.003686177682482792, 0.0027646332618620944, 0.0027646332618620944, 9.215444206206978E-4, 9.215444206206978E-4]
+[0.0, 0.9137205196116396, 0.05546364951030729, 0.022931012347791626, 0.0026282728434204455, 0.0019712046325653346, 0.0019712046325653346, 6.570682108551113E-4, 6.570682108551113E-4]
+[0.0, 0.4348742321357199, 0.284834930002158, 0.23979815925233586, 0.013497559536595444, 0.010123169652446586, 0.010123169652446586, 0.0033743898841488607, 0.0033743898841488607]
+[0.0, 0.4113669046473151, 0.28678807830160635, 0.2610746751421802, 0.013590113969632868, 0.010192585477224654, 0.010192585477224654, 0.0033975284924082166, 0.0033975284924082166]
+[0.0, 0.5134283885596455, 0.24313972133933362, 0.20886668212813608, 0.011521735990961563, 0.008641301993221174, 0.008641301993221174, 0.0028804339977403903, 0.0028804339977403903]
+[0.0, 0.6937754869950873, 0.1758755788518959, 0.10534612536932582, 0.008334269594563652, 0.00625070219592274, 0.00625070219592274, 0.0020835673986409125, 0.0020835673986409125]
+[0.0, 0.8575617948580357, 0.08507981543021606, 0.04526328037115735, 0.004031703113530326, 0.0030237773351477447, 0.0030237773351477447, 0.0010079257783825813, 0.0010079257783825813]
+[0.0, 0.8512801022525969, 0.08826034233553497, 0.04791229628127099, 0.004182419710199001, 0.0031368147826492513, 0.0031368147826492513, 0.00104560492754975, 0.00104560492754975]
+[0.0, 0.7755184545885278, 0.13059758970565072, 0.0753179524873132, 0.00618866773950277, 0.004641500804627078, 0.004641500804627078, 0.0015471669348756923, 0.0015471669348756923]
+[0.0, 0.8570562982159793, 0.08538167144930674, 0.045424008564922715, 0.004046007256597067, 0.0030345054424478013, 0.0030345054424478013, 0.0010115018141492666, 0.0010115018141492666]
+[0.0, 0.856220948622855, 0.08588049756583115, 0.0456896179664177, 0.004069645281631942, 0.0030522339612239564, 0.0030522339612239564, 0.0010174113204079853, 0.0010174113204079853]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.8782636050554478, 0.07452396625833617, 0.03661795905988694, 0.0035314898754429517, 0.0026486174065822148, 0.0026486174065822148, 8.828724688607379E-4, 8.828724688607379E-4]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.8833516223278373, 0.07197338598225665, 0.03444311743552491, 0.0034106247514604773, 0.002557968563595358, 0.002557968563595358, 8.526561878651192E-4, 8.526561878651192E-4]
+[0.0, 0.8582211945645658, 0.08889584898746129, 0.04024535247585418, 0.004212534657372837, 0.003159400993029628, 0.003159400993029628, 0.001053133664343209, 0.001053133664343209]
+[0.0, 0.9211847117938832, 0.05120356888963386, 0.02033252199785976, 0.002426399106207806, 0.001819799329655855, 0.001819799329655855, 6.065997765519515E-4, 6.065997765519515E-4]
+[0.0, 0.7201037509613293, 0.1533655694618601, 0.10472793679530232, 0.007267580927169422, 0.005450685695377068, 0.005450685695377068, 0.0018168952317923553, 0.0018168952317923553]
+[0.0, 0.7342820946663161, 0.14723874260691153, 0.09754742137312036, 0.006977247117883975, 0.005232935338412983, 0.005232935338412983, 0.0017443117794709935, 0.0017443117794709935]
+[0.0, 0.7789649161433827, 0.13381046661490456, 0.06820186529474538, 0.006340917315655799, 0.00475568798674185, 0.00475568798674185, 0.0015852293289139495, 0.0015852293289139495]
+[0.0, 0.8774958887275224, 0.07499382426024762, 0.036849021473393244, 0.0035537551796122717, 0.0026653163847092046, 0.0026653163847092046, 8.884387949030679E-4, 8.884387949030679E-4]
+[0.0, 0.8782636050554478, 0.07452396625833617, 0.03661795905988694, 0.0035314898754429517, 0.0026486174065822148, 0.0026486174065822148, 8.828724688607379E-4, 8.828724688607379E-4]
+[0.0, 0.8779339136623299, 0.07472574419804034, 0.03671718737534056, 0.003541051588096337, 0.0026557886910722533, 0.0026557886910722533, 8.852628970240841E-4, 8.852628970240841E-4]
+[0.0, 0.8689223346201713, 0.07990435864672404, 0.0398139502308018, 0.0037864521674341772, 0.002839839125575633, 0.002839839125575633, 9.466130418585441E-4, 9.466130418585441E-4]
+[0.0, 0.8546721633517643, 0.0865270877158731, 0.04649989259464752, 0.004100285445904984, 0.0030752140844287385, 0.0030752140844287385, 0.0010250713614762459, 0.0010250713614762459]
+[0.0, 0.8701771979205339, 0.07877546284503133, 0.039848468719161555, 0.003732956838424335, 0.002799717628818252, 0.002799717628818252, 9.332392096060838E-4, 9.332392096060838E-4]
+[0.0, 0.8784610515009056, 0.07440312488208124, 0.0365585330319328, 0.003525763528360194, 0.002644322646270146, 0.002644322646270146, 8.814408820900485E-4, 8.814408820900485E-4]
+[0.0, 0.8914042016692508, 0.06769819524188346, 0.0312734981296478, 0.0032080349864058505, 0.002406026239804388, 0.002406026239804388, 8.020087466014625E-4, 8.020087466014625E-4]
+[0.0, 0.7520841505225175, 0.1403992016606731, 0.08755722868983226, 0.0066531397089923195, 0.004989854781744241, 0.004989854781744241, 0.0016632849272480797, 0.0016632849272480797]
+[0.0, 0.6129543067368707, 0.20966381089168457, 0.14757567387561268, 0.009935402831943963, 0.007451552123957973, 0.007451552123957973, 0.0024838507079859903, 0.0024838507079859903]
+[0.0, 0.911870445246063, 0.05642446303081128, 0.023683682104512466, 0.0026738032062044994, 0.0020053524046533726, 0.0020053524046533726, 6.684508015511246E-4, 6.684508015511246E-4]
+[0.0, 0.8784774929098204, 0.07439306239158176, 0.03655358461641853, 0.0035252866940597024, 0.002643965020544777, 0.002643965020544777, 8.813216735149254E-4, 8.813216735149254E-4]
+[0.0, 0.8736399642580216, 0.07735371572304262, 0.03800956779468359, 0.0036655840747507194, 0.00274918805606304, 0.00274918805606304, 9.163960186876799E-4, 9.163960186876799E-4]
+[0.0, 0.6101106334365051, 0.21079788130259244, 0.14912405514569474, 0.009989143371735919, 0.007491857528801941, 0.007491857528801941, 0.0024972858429339793, 0.0024972858429339793]
+[0.0, 0.6928121660718066, 0.17574369151360403, 0.10646008298724335, 0.008328019809115272, 0.006246014856836456, 0.006246014856836456, 0.002082004952278818, 0.002082004952278818]
+[0.0, 0.8698673509145071, 0.07884128431529486, 0.04008313694877948, 0.003736075940472883, 0.002802056955354663, 0.002802056955354663, 9.340189851182207E-4, 9.340189851182207E-4]
+[0.0, 0.8711742795935766, 0.07817059755312694, 0.03954224114517957, 0.003704293902705611, 0.002778220427029209, 0.002778220427029209, 9.260734756764027E-4, 9.260734756764027E-4]
+[0.0, 0.8758499713413174, 0.07579796908520858, 0.03757647526778975, 0.0035918614352280194, 0.002693896076421015, 0.002693896076421015, 8.979653588070046E-4, 8.979653588070046E-4]


### PR DESCRIPTION
This PR fixes the bug in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8367.

Before I fixed glm offset column support, the old glm mojo cannot handle offset columns and in some tests, there are no valid output but this:

java.lang.UnsupportedOperationException: `offset` column is not supported

After the glm offset column support in glm mojo, the output is now:
[15.367033442452353, 0.0]
[13.863126375563912, 0.0]
[17.525638898853458, 0.0]
[26.962901811086926, 0.0]
[26.15290883078117, 0.0]
[33.00034026879588, 0.0]
[29.519847327713162, 0.0]
[33.70860845135371, 0.0]
[30.381642560420527, 0.0]
[30.783844549430324, 0.0]
[33.118794072207635, 0.0]
[32.00721190471421, 0.0],....

Hence, the two files generated should be different and it is not a bug.  I added in the check to look for this condition.  If the old file contains  `offset` column is not supported, it is ok and not an error.